### PR TITLE
Parse responses from the API to be more dev-friendly

### DIFF
--- a/src/core/api-client.ts
+++ b/src/core/api-client.ts
@@ -17,6 +17,7 @@ import { stringify } from "safe-stable-stringify"
 import * as v from "valibot"
 import { sha256 } from "../utils/sha-256"
 import type { ApiClientConfig } from "./types"
+import { ApiError, apiErrorIssuesSchema } from "./errors/api-error"
 
 export interface RequestOptions {
   method: string
@@ -24,14 +25,18 @@ export interface RequestOptions {
   body?: unknown
 }
 
-const apiResponseSchema = v.variant("ok", [
-  v.object({
-    ok: v.literal(false),
-    message: v.string(),
-    cause: v.optional(v.unknown())
-  }),
-  v.object({ ok: v.literal(true), data: v.nullable(v.unknown()) })
-])
+const apiSuccessSchema = v.object({
+  ok: v.literal(true),
+  data: v.nullable(v.unknown())
+})
+
+const apiErrorSchema = v.object({
+  ok: v.literal(false),
+  error: v.string(),
+  issues: v.optional(v.array(apiErrorIssuesSchema))
+})
+
+const apiResponseSchema = v.variant("ok", [apiSuccessSchema, apiErrorSchema])
 
 const agentMetadataSchema = v.object({
   did: didUriSchema
@@ -194,15 +199,37 @@ export class ApiClient {
     const response = await fetch(url, init)
 
     if (!response.ok) {
-      throw new Error(`Request failed: ${response.statusText}`)
+      await handleErrorResponse(response)
     }
 
     const result = v.parse(apiResponseSchema, await response.json())
 
     if (!result.ok) {
-      throw new Error(result.message)
+      handleApiError(result, response.status)
     }
 
     return v.parse(schema, result.data)
   }
+}
+
+function handleApiError(
+  result: v.InferOutput<typeof apiErrorSchema>,
+  statusCode?: number
+): never {
+  throw new ApiError(result.error, result.issues ?? [], statusCode)
+}
+
+async function handleErrorResponse(response: Response): Promise<never> {
+  let result: v.InferOutput<typeof apiErrorSchema>
+
+  try {
+    result = v.parse(apiErrorSchema, await response.json())
+  } catch {
+    result = {
+      ok: false,
+      error: `Request failed: ${response.statusText}`
+    }
+  }
+
+  handleApiError(result, response.status)
 }

--- a/src/core/errors/api-error.ts
+++ b/src/core/errors/api-error.ts
@@ -1,0 +1,23 @@
+import * as v from "valibot"
+
+export const apiErrorIssuesSchema = v.variant("kind", [
+  v.looseObject({
+    kind: v.literal("policy")
+  }),
+  v.looseObject({
+    kind: v.picklist(["schema", "validation", "transformation"])
+  })
+])
+
+type ApiErrorIssue = v.InferOutput<typeof apiErrorIssuesSchema>
+
+export class ApiError extends Error {
+  issues: ApiErrorIssue[] = []
+  statusCode?: number
+
+  constructor(message: string, issues: ApiErrorIssue[], statusCode?: number) {
+    super(message)
+    this.issues = issues
+    this.statusCode = statusCode
+  }
+}

--- a/src/demo/addition-demo.ts
+++ b/src/demo/addition-demo.ts
@@ -52,7 +52,11 @@ async function runAgentA(message: string) {
           try {
             return await callAgent({ message })
           } catch (error) {
-            console.error(">>>> error calling addition agent", error)
+            console.error(
+              ">>>> error calling addition agent:",
+              (error as Error).message,
+              JSON.stringify(error, null, 2)
+            )
             return {
               error: true,
               message: error instanceof Error ? error.message : "Unknown error"


### PR DESCRIPTION
Requires https://github.com/catena-labs/dashboard/pull/211

Handles Error responses from the API, specifically building an ApiError type that can contain the issues that are returned from the API. The types are pretty loose at the time.