### PR TITLE
Don't expect or require a challenge as part of handshakeResponse step

### DIFF
--- a/src/core/handshake.ts
+++ b/src/core/handshake.ts
@@ -278,9 +278,9 @@ export class HandshakeClient {
       payload
     )
 
-    if (expectedChallenge && expectedChallenge !== nonce) {
+    if (expectedChallenge !== nonce) {
       throw new Error(
-        `Expected challenge ${expectedChallenge} but got ${nonce ?? "undefined"}`
+        `Expected challenge ${expectedChallenge ?? "undefined"} but got ${nonce ?? "undefined"}`
       )
     }
   }


### PR DESCRIPTION
The handdshake flow is:
-> handshake-init
<- handshake-response (with jti as challenge)
-> handshake-complete (signed jti as nonce, new jti as challenge) <- handshake-final (signed jti as nonce)

The 2nd step, handshake-response, does not require any sort of signed challenge. This explicitly skips that step to prevent issues where the challenge cache could hold old challenge data.