### PR TITLE
Add an optional URL as a return type on payment-requests, payments

### DIFF
--- a/src/core/api-client.ts
+++ b/src/core/api-client.ts
@@ -81,25 +81,27 @@ export class ApiClient {
       currencyCode = "USD",
       description
     }: { currencyCode?: string; description?: string } = {}
-  ): Promise<{ paymentToken: string }> {
+  ): Promise<{ paymentToken: string; url?: string }> {
     return this.request(
       {
         method: "POST",
         path: "/v1/payment-requests",
         body: { amount: minorUnits, currencyCode, description }
       },
-      v.object({ paymentToken: v.string() })
+      v.object({ paymentToken: v.string(), url: v.optional(v.string()) })
     )
   }
 
-  async executePayment(paymentToken: string): Promise<{ receipt: JwtString }> {
+  async executePayment(
+    paymentToken: string
+  ): Promise<{ receipt: JwtString; url?: string }> {
     return this.request(
       {
         method: "POST",
         path: "/v1/payments",
         body: { paymentToken }
       },
-      v.object({ receipt: jwtStringSchema })
+      v.object({ receipt: jwtStringSchema, url: v.optional(v.string()) })
     )
   }
 


### PR DESCRIPTION
Since this feature may potentially change, it marks it as optional to
allow for API modification without coordinating SDK release
