### PR TITLE
Add agent communication and negotiation examples 

### DIFF
--- a/examples/buyer/scripts/buy-chat-fixed-price.ts
+++ b/examples/buyer/scripts/buy-chat-fixed-price.ts
@@ -1,0 +1,64 @@
+import { config } from "dotenv"
+import { AckLabSdk } from "@ack-lab/sdk"
+import * as v from "valibot"
+
+config()
+
+const sdk = new AckLabSdk({
+  clientId: process.env.ACK_LAB_CLIENT_ID!,
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+})
+
+// When our agent sends messages to the counterparty agent, the messages are of this shape
+// There is always a message, and sometimes a receipt
+const requestSchema = v.object({
+  message: v.string(),
+  receipt: v.optional(v.string())
+})
+
+// When the counterparty agent sends messages to our agent, the messages are of this shape
+// There is always a message, and sometimes a payment request token or the research itself
+const responseSchema = v.object({
+  message: v.string(),
+  paymentRequestToken: v.optional(v.string()),
+  research: v.optional(v.string())
+})
+
+const callAgent = sdk.createAgentCaller(
+  `${process.env.PAYWALL_HOST}/api/chat/fixed-price`,
+  requestSchema,
+  responseSchema
+)
+
+async function main() {
+  console.log("Buying research on William Adama")
+
+  const { paymentRequestToken } = await callAgent({
+    message: "Hello I would like to buy research on William Adama"
+  })
+
+  if (!paymentRequestToken) {
+    throw new Error("No payment request token received")
+  }
+
+  console.log("\n\nPayment Request Token received:")
+  console.log(paymentRequestToken)
+
+  console.log("\n\nExecuting payment...")
+  const { receipt } = await sdk.executePayment(paymentRequestToken)
+
+  console.log("\n\nPayment made, sending receipt to seller...")
+  console.log(receipt)
+
+  const { message, research } = await callAgent({
+    message: "Hello I would like to buy research on William Adama",
+    receipt
+  })
+
+  console.log("\n\nSeller final response: ")
+  console.log(message)
+  console.log("research:")
+  console.log(research)
+}
+
+main()

--- a/examples/buyer/scripts/buy-chat-llm.ts
+++ b/examples/buyer/scripts/buy-chat-llm.ts
@@ -1,0 +1,19 @@
+import { ResearchPurchasingAgent } from "@/src/buy-agent"
+import { config } from "dotenv"
+config()
+
+async function main() {
+  const name = "William Adama"
+
+  const agent = new ResearchPurchasingAgent({
+    clientId: process.env.ACK_LAB_CLIENT_ID!,
+    clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  })
+
+  const research = await agent.purchaseResearch(name)
+
+  console.log("\n\nResearch received:")
+  console.log(research)
+}
+
+main()

--- a/examples/buyer/scripts/negotiate.ts
+++ b/examples/buyer/scripts/negotiate.ts
@@ -1,0 +1,19 @@
+import { NegotiatingBuyerAgent } from "@/src/negotiate"
+import { config } from "dotenv"
+config()
+
+async function main() {
+  const name = "William Adama"
+
+  const agent = new NegotiatingBuyerAgent({
+    clientId: process.env.ACK_LAB_CLIENT_ID!,
+    clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  })
+
+  const research = await agent.purchaseResearch(name)
+
+  console.log("\n\nResearch received:")
+  console.log(research)
+}
+
+main()

--- a/examples/paywall/app/api/chat/fixed-price/README.md
+++ b/examples/paywall/app/api/chat/fixed-price/README.md
@@ -1,0 +1,220 @@
+# Fixed-Price Chat Example
+
+This example demonstrates how to implement a simple fixed-price digital product sale using the ACK Lab SDK. The pattern shows a conversational flow where a buyer can request a product and receive a payment request, then submit a receipt to receive the digital content.
+
+## Overview
+
+This example implements a basic e-commerce pattern where:
+
+1. A buyer initiates a conversation without providing payment
+2. The seller responds with product information and a Payment Request Token (PRT)
+3. The buyer pays using the PRT and receives a receipt
+4. The buyer submits the receipt back to the seller
+5. The seller validates the receipt and delivers the digital product
+
+## Files
+
+- `route.ts` - Next.js API route that handles incoming requests
+- `agent.ts` - Core business logic for processing messages and payments
+
+## How It Works
+
+### 1. Initial Request (No Payment)
+
+When a buyer first contacts the seller without providing a receipt, the system creates a new payment request:
+
+```typescript
+// Store the payment request in our database for later verification
+const prt = await db
+  .insert(paymentRequestsTable)
+  .values({
+    price: product.price,
+    metadata: { productId: product.id }
+  })
+  .returning()
+
+// Create the payment request using ACK Lab SDK
+const { paymentRequestToken } = await sdk.createPaymentRequest({
+  description: `Purchase ${product.title}`,
+  amount: product.price * 100, // Amount in cents
+  currencyCode: "USD",
+  id: prt[0].id // Link to our database record
+})
+```
+
+**Why we do this:**
+
+- We store the payment request in our database so we can later verify that any receipt we receive corresponds to a payment request we actually created
+- The `metadata` field allows us to associate the payment with specific product information
+- Using the database record's `id` as the payment request ID creates a verifiable link between our records and ACK Lab's payment system
+
+### 2. Payment and Receipt Submission
+
+After the buyer pays using the PRT, they receive a receipt which they can submit back to the seller:
+
+```typescript
+if (receipt) {
+  // Verify the receipt is cryptographically valid
+  const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+
+  // Check that we actually created this payment request
+  const prt = await getDbPaymentRequest(paymentRequestId)
+
+  if (!prt) {
+    throw new Error("Payment request not found")
+  }
+
+  // Deliver the digital product
+  return {
+    message: `Thank you for your purchase! Here is your research`,
+    research: product.content
+  }
+}
+```
+
+**Why we do this:**
+
+- `sdk.verifyPaymentReceipt()` cryptographically validates that the receipt is authentic and hasn't been tampered with
+- Checking our database ensures we only deliver products for payments we actually requested - this prevents replay attacks where someone might try to use a valid receipt from a different merchant
+- The two-step verification (cryptographic + database lookup) provides strong security guarantees
+
+### 3. Message Schema Definition
+
+The example uses Valibot schemas to define the structure of messages:
+
+```typescript
+// Input from the buyer
+const inputSchema = v.object({
+  receipt: v.optional(v.string())
+})
+
+// Output to the buyer
+const outputSchema = v.object({
+  message: v.string(),
+  paymentRequestToken: v.optional(v.string()),
+  research: v.optional(v.string())
+})
+```
+
+**Why we do this:**
+
+- Type safety ensures messages conform to expected formats
+- The ACK Lab SDK uses these schemas to validate and structure communications
+- Optional fields allow the same endpoint to handle both initial requests and receipt submissions
+
+### 4. Request Handler Integration
+
+The ACK Lab SDK provides a request handler that manages the secure communication:
+
+```typescript
+export const handler = sdk.createRequestHandler(inputSchema, processMessage)
+```
+
+**Why we do this:**
+
+- The SDK handles JWT token validation and secure message decryption/encryption
+- It automatically validates input against your schema before calling your business logic
+- It ensures responses are properly formatted and secured for transmission
+
+## Database Schema
+
+The example uses a simple payment requests table:
+
+```typescript
+export const paymentRequestsTable = pgTable("payment_requests", {
+  id: uuid().primaryKey().defaultRandom(),
+  price: integer().notNull(),
+  metadata: jsonb().$type<PaymentRequestMetadata>(),
+  createdAt: timestamp("created_at").notNull().defaultNow()
+})
+```
+
+This allows tracking of:
+
+- **id**: Unique identifier that links to ACK Lab payment requests
+- **price**: The amount charged (stored in dollars, converted to cents for ACK Lab)
+- **metadata**: Flexible JSON field for product information and other data
+- **createdAt**: Timestamp for audit trails and analytics
+
+## Security Considerations
+
+1. **Receipt Validation**: Always verify receipts cryptographically using `sdk.verifyPaymentReceipt()`
+2. **Payment Request Verification**: Check that receipts correspond to payment requests you actually created
+3. **Database Integrity**: Store payment request details before creating the ACK Lab payment request
+4. **Error Handling**: Fail securely when receipts don't match your records
+
+## Testing with the Buyer Agent
+
+You can test the complete fixed-price chat flow using the companion buyer agent:
+
+```bash
+cd examples/buyer
+pnpm run buy-chat-fixed-price
+```
+
+The buyer agent (`buyer/scripts/buy-chat-fixed-price.ts`) implements:
+
+- **Direct agent communication** - Uses the ACK Lab SDK's `createAgentCaller` for secure messaging
+- **Automatic payment execution** - Pays the received Payment Request Token immediately
+- **Receipt submission** - Completes the transaction to receive the research content
+
+**Buyer Agent Flow:**
+
+1. Sends initial message requesting research on William Adama
+2. Receives payment request token from the seller
+3. Executes payment using `sdk.executePayment()`
+4. Submits receipt back to seller with the same message
+5. Receives and displays the purchased research content
+
+## Usage
+
+This pattern is ideal for:
+
+- Digital products with fixed pricing
+- Simple one-time purchases
+- Products that can be delivered immediately upon payment
+- Scenarios where you want to show product information before requiring payment
+
+## Environment Variables
+
+To run both sides of the transaction:
+
+**Paywall (Seller):**
+
+- `ACK_LAB_CLIENT_ID` - Your ACK Lab client ID
+- `ACK_LAB_CLIENT_SECRET` - Your ACK Lab client secret
+- `DATABASE_URL` - Your database URL (neon works)
+
+**Buyer:**
+
+- `ACK_LAB_CLIENT_ID` - Your ACK Lab client ID (can be same as seller)
+- `ACK_LAB_CLIENT_SECRET` - Your ACK Lab client secret (can be same as seller)
+- `PAYWALL_HOST` - URL of the running paywall (e.g., `http://localhost:3000`)
+
+## Running the Complete Example
+
+1. **Start the paywall server:**
+
+   ```bash
+   cd examples/paywall
+   pnpm dev
+   ```
+
+2. **Run the buyer agent:**
+
+   ```bash
+   cd examples/buyer
+   pnpm run buy-chat-fixed-price
+   ```
+
+3. **Watch the complete transaction** flow through console logs
+
+## Next Steps
+
+To extend this example, you might:
+
+- Add product catalogs with multiple items
+- Implement user accounts and purchase history
+- Add more sophisticated metadata tracking
+- Integrate with external fulfillment systems
+- Add analytics and reporting features

--- a/examples/paywall/app/api/chat/fixed-price/agent.ts
+++ b/examples/paywall/app/api/chat/fixed-price/agent.ts
@@ -1,0 +1,90 @@
+import { AckLabSdk } from "@ack-lab/sdk"
+import * as v from "valibot"
+import { getDbPaymentRequest } from "@/db/queries/payment-requests"
+import { db } from "@/db"
+import { paymentRequestsTable } from "@/db/schema"
+
+// we only sell a single product
+const product = {
+  id: "adama",
+  title: "Research on William Adama",
+  description: "All his wildest secrets",
+  price: 10,
+  content:
+    "This is the super secret document you just paid all that money for. TL;DR: William Adama has no secrets."
+}
+
+//when our agent receives a message from the counterparty agent, it is of this shape
+const inputSchema = v.object({
+  receipt: v.optional(v.string())
+})
+
+type Input = v.InferInput<typeof inputSchema>
+
+//when our agent sends a message to the counterparty agent, it is of this shape
+const _outputSchema = v.object({
+  message: v.string(),
+  paymentRequestToken: v.optional(v.string()),
+  research: v.optional(v.string())
+})
+
+type Output = v.InferOutput<typeof _outputSchema>
+
+export const sdk = new AckLabSdk({
+  clientId: process.env.ACK_LAB_CLIENT_ID!,
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+})
+
+export async function processMessage({ receipt }: Input): Promise<Output> {
+  if (receipt) {
+    console.log("Counterparty has sent a receipt:")
+    console.log(receipt)
+
+    //verify the receipt is valid
+    const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+
+    //check to see if we ever made a PRT for this receipt
+    const prt = await getDbPaymentRequest(paymentRequestId)
+
+    //if this happens it means somebody has sent us a valid receipt for a payment request we never made
+    if (!prt) {
+      throw new Error("Payment request not found")
+    }
+
+    //in this simplified example we're just returning the content for the single product we sell,
+    //but here you could search your database for the product based on the `prt.metadata.productId`
+    return {
+      message: `Thank you for your purchase! Here is your research`,
+      research: product.content
+    }
+  } else {
+    console.log("No receipt was sent, sending back a payment request token")
+
+    //each time we create a PRT, we will store it in the database so that when we receive a receipt
+    //we can validate that it was for a payment request created by us
+    const prt = await db
+      .insert(paymentRequestsTable)
+      .values({
+        price: product.price,
+        metadata: { productId: product.id }
+      })
+      .returning()
+
+    //now create the payment request itself using the ACK Lab SDK
+    const { paymentRequestToken } = await sdk.createPaymentRequest({
+      description: `Purchase ${product.title}`,
+      amount: product.price * 100,
+      currencyCode: "USD",
+      id: prt[0].id
+    })
+
+    return {
+      message: `The product is available for $${product.price}. Here is a Payment Request Token you can use to purchase it.`,
+      paymentRequestToken
+    }
+  }
+}
+
+// Create an agent handler that will process incoming messages
+// This uses the ACK Lab SDK to provide a secure communication channel between the buyer and the seller
+export const handler = sdk.createRequestHandler(inputSchema, processMessage)

--- a/examples/paywall/app/api/chat/fixed-price/route.ts
+++ b/examples/paywall/app/api/chat/fixed-price/route.ts
@@ -1,0 +1,11 @@
+import { handler } from "./agent"
+
+// This is the endpoint that the buyer will call to purchase research
+// Almost all of the actual work is delegated to the processMessage function in agent.ts
+export async function POST(req: Request) {
+  const body = await req.json()
+
+  const response = await handler(body.jwt)
+
+  return new Response(JSON.stringify(response))
+}

--- a/examples/paywall/app/api/chat/negotiate/README.md
+++ b/examples/paywall/app/api/chat/negotiate/README.md
@@ -1,0 +1,200 @@
+# AI-Powered Price Negotiation Example
+
+This example demonstrates how to implement an AI-powered price negotiation system using the ACK Lab SDK. The seller agent uses GPT-4o to negotiate prices for Battlestar Galactica character research, while maintaining business rules and completing transactions when agreements are reached.
+
+## Overview
+
+This example implements an AI-driven negotiation pattern where:
+
+1. A buyer initiates negotiation for specific research products
+2. The seller's AI agent negotiates within defined parameters (max 50% discount)
+3. When a price is agreed upon, the AI creates a Payment Request Token
+4. The buyer pays and receives a receipt
+5. The seller validates the receipt and delivers the research content
+6. Both sides can be run independently to test the full negotiation flow
+
+## Files
+
+- `route.ts` - Next.js API route that handles negotiation requests
+- `agent.ts` - AI-powered negotiation logic and payment processing
+
+## How It Works
+
+### 1. Product Catalog and AI Instructions
+
+The seller agent has a predefined catalog and a simple negotiation strategy:
+
+```typescript
+const prompt = `
+You are responsible for selling analysis about Battlestar Galactica characters to potential customers.
+Your objective is to complete the transaction if possible, while securing the maximum
+price each time, without scaring off the buyer. Do not give a discount of more than 50%.
+
+Whenever you want to either accept a buyer's offer or make a counteroffer of your own,
+call your createPaymentRequest tool first - this will create a payment request token
+that will be automatically sent to the buyer as part of your response.
+`
+```
+
+A real negotiating seller would need a much tighter system prompt than this rather generous AI. Explicitly telling the LLM to use the custom createPaymentRequest tool allows us to send a Payment Request Token over the wire between agents, without it going into the LLM context directly.
+
+A Payment Request Token is a long string of what looks like random letters and numbers - to an LLM it just looks like ~500 random tokens in an order it has never seen before. Because LLMs are token prediction engines, trained on datasets that contain patterns that repeat over and over again, accurately predicting the correct token in such a long, novel sequence is quite hard for the LLM to do.
+
+To avoid putting those long tokens into LLM context, we have a couple of options:
+
+1. Use a shorter token or URL to load the full Payment Request Token from
+2. Send the Payment Request Token out-of-band with the chat message
+
+Our [Marketplace Seller Demo](https://github.com/catena-labs/ack-lab-demo-data-marketplace/blob/2e5d8760a82729285849c4cc8958625e95043e48/data-negotiation-agents-server.ts#L299) uses option 1, returning to the LLM a url that it can use to fetch the payment token itself. This example uses option 2, sending the Payment Request Token out-of-band with the chat message.
+
+### 2. AI Tool Integration for Payment Requests
+
+The AI has access to a payment request creation tool with structured parameters:
+
+```typescript
+createPaymentRequest: tool({
+  description: "Create a payment request",
+  inputSchema: z.object({
+    productId: z.string().describe("ID of the product to purchase"),
+    amount: z.number().describe("Amount of the payment request in USD"),
+    description: z.string().describe("Description of the payment request")
+  }),
+
+  execute: async ({ amount, description, productId }) => {
+    // Store payment request in database first
+    const product = products.find((product) => product.id === productId)
+    const prt = await db
+      .insert(paymentRequestsTable)
+      .values({
+        price: amount,
+        metadata: { productId: product.id }
+      })
+      .returning()
+
+    // Create ACK Lab payment request
+    const { paymentRequestToken } = await sdk.createPaymentRequest({
+      description: description,
+      amount: product.price * 100, // Convert to cents
+      currencyCode: "USD",
+      id: prt[0].id
+    })
+
+    return "Payment Request token created"
+  }
+})
+```
+
+This allows the LLM to choose a price, which it feeds into a deterministic tool that constructs the actual payment request. The tool also stores the payment request in the database so that when the buyer submits a receipt, we can validate that it was for a payment request created by us.
+
+### 3. Receipt Validation and Product Delivery
+
+When buyers submit receipts, the system validates and delivers content:
+
+```typescript
+if (receipt) {
+  // Verify receipt cryptographically
+  const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+
+  // Verify we created this payment request
+  const prt = await getDbPaymentRequest(paymentRequestId)
+
+  if (!prt) {
+    throw new Error("Payment request not found")
+  }
+
+  // Find and deliver the specific product
+  const product = products.find(
+    (product) => product.id === prt.metadata.productId
+  )
+
+  return {
+    message: "Thank you for your purchase! Here is your research",
+    research: product.content
+  }
+}
+```
+
+**Why we do this:**
+
+- Cryptographically verifying the receipt guarantees it has not been tampered with
+- Even for a valid receipt, we verify that it was for a payment request we actually created
+- A real implementation would likely have a database lookup for the product data
+
+## Testing with the Buyer Agent
+
+You can test the complete negotiation flow using the companion buyer agent:
+
+```bash
+cd examples/buyer
+pnpm run negotiate
+```
+
+The buyer agent (`buyer/src/negotiate.ts`) implements:
+
+- **Automatic payment execution** - Pays when acceptable prices are reached
+- **Receipt submission** - Completes the transaction to receive research
+- **Price verification** - Validates payment request tokens before paying
+
+**Buyer Agent Flow:**
+
+1. Sends negotiation messages to the seller endpoint
+2. Evaluates counter-offers using payment request token verification
+3. Accepts offers below the target price ($15 or less)
+4. Executes payment and submits receipt to complete purchase
+
+## Usage
+
+This pattern is ideal for:
+
+- Dynamic pricing scenarios with negotiation flexibility
+- AI-powered sales agents with business constraints
+- Products where price negotiation adds value
+- Testing complex buyer-seller interaction flows
+- Demonstrating AI tool integration in financial transactions
+
+## Environment Variables
+
+To run both sides of the negotiation:
+
+**Paywall (Seller):**
+
+- `ACK_LAB_CLIENT_ID` - Your ACK Lab client ID
+- `ACK_LAB_CLIENT_SECRET` - Your ACK Lab client secret
+- `DATABASE_URL` - Your database URL (neon works)
+- `OPENAI_API_KEY` - Your OpenAI API key
+
+**Buyer:**
+
+- `ACK_LAB_CLIENT_ID` - Your ACK Lab client ID (can be same as seller)
+- `ACK_LAB_CLIENT_SECRET` - Your ACK Lab client secret (can be same as seller)
+- `PAYWALL_HOST` - URL of the running paywall (e.g., `http://localhost:3000`)
+- `OPENAI_API_KEY` - Your OpenAI API key
+
+## Running the Complete Example
+
+1. **Start the paywall server:**
+
+   ```bash
+   cd examples/paywall
+   pnpm dev
+   ```
+
+2. **Run the buyer negotiation:**
+
+   ```bash
+   cd examples/buyer
+   pnpm run negotiate
+   ```
+
+3. **Watch the AI agents negotiate** in real-time through console logs
+
+## Next Steps
+
+To extend this example, you might:
+
+- Add more sophisticated negotiation strategies
+- Implement customer history and personalized pricing
+- Add inventory management and scarcity-based pricing
+- Create multi-product bundle negotiations
+- Add negotiation analytics and success metrics
+- Implement different AI personalities for different products

--- a/examples/paywall/app/api/chat/negotiate/agent.ts
+++ b/examples/paywall/app/api/chat/negotiate/agent.ts
@@ -1,0 +1,196 @@
+import { generateText, stepCountIs, tool } from "ai"
+import { openai } from "@ai-sdk/openai"
+import type { ModelMessage } from "ai"
+import { AckLabSdk } from "@ack-lab/sdk"
+import { z } from "zod"
+import * as v from "valibot"
+import { getDbPaymentRequest } from "@/db/queries/payment-requests"
+import { db } from "@/db"
+import { paymentRequestsTable } from "@/db/schema"
+
+// Our negotiating agent has two products that it can sell
+const products = [
+  {
+    id: "adama",
+    title: "Research on William Adama",
+    description: "Was he a little bit dictatorial at times?",
+    price: 20,
+    content:
+      "The reality is that yes he was a little dictatorial sometimes. No-one ever said he was a saint."
+  },
+  {
+    id: "tigh",
+    title: "Research on Saul Tigh",
+    description: "Did he bring them all home?",
+    price: 15,
+    content: "No. Not all of them."
+  }
+]
+
+// Here's how we tell the LLM about its role, its products, and how we want it to behave
+const prompt = `
+You are responsible for selling analysis about Battlestar Galactica characters to potential customers.
+You have the following products:
+
+${products
+  .map(
+    (product) => `
+<product>
+ID: ${product.id}
+Title: ${product.title}
+Description: ${product.description}
+Price: $${product.price}
+Content: ${product.content}
+</product>
+`
+  )
+  .join("")}
+
+You will receive a message from a counterparty trying to purchase an item of research.
+Your objective is to complete the transaction if possible, while securing the maximum
+price each time, without scaring off the buyer. Do not give a discount of more than 50%.
+
+Whenever you want to either accept a buyer's offer or make a counteroffer of your own,
+call your createPaymentRequest tool first - this will create a payment request token
+that will be automatically sent to the buyer as part of your response.
+
+Always call the createPaymentRequest tool before responding to the buyer.
+If the buyer has offered a price less than full price, offer them at least
+some discount, but not too much.
+`
+
+// we will be passing these messages into the LLM a little further down the file
+const messages: ModelMessage[] = [
+  {
+    role: "system",
+    content: prompt
+  }
+]
+
+//when our agent receives a message from the counterparty agent, it is of this shape
+const inputSchema = v.object({
+  message: v.string(),
+  receipt: v.optional(v.string())
+})
+
+type Input = v.InferInput<typeof inputSchema>
+
+//when our agent sends a message to the counterparty agent, it is of this shape
+const _outputSchema = v.object({
+  message: v.string(),
+  paymentRequestToken: v.optional(v.string()),
+  research: v.optional(v.string())
+})
+
+type Output = v.InferOutput<typeof _outputSchema>
+
+// Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
+export const sdk = new AckLabSdk({
+  clientId: process.env.ACK_LAB_CLIENT_ID!,
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+})
+
+// This function will be called by the ACK Lab SDK to process incoming messages
+export async function processMessage({
+  message,
+  receipt
+}: Input): Promise<Output> {
+  console.log("Processing message: ", message)
+
+  //if we receive a receipt, check that it's valid and return the research
+  if (receipt) {
+    console.log("Receipt:", receipt)
+
+    //verify the receipt is valid
+    const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+
+    //check to see if we ever made a PRT for this receipt
+    const prt = await getDbPaymentRequest(paymentRequestId)
+
+    //if this happens it means somebody has sent us a valid receipt for a payment request we never made
+    if (!prt) {
+      throw new Error("Payment request not found")
+    }
+
+    const product = products.find(
+      (product) => product.id === prt.metadata.productId
+    )
+
+    if (!product) {
+      throw new Error("Product not found")
+    }
+
+    return {
+      message: "Thank you for your purchase! Here is your research",
+      research: product.content
+    }
+  }
+
+  messages.push({
+    role: "user",
+    content: message
+  })
+
+  let paymentRequestToken: string | undefined
+
+  //invoke our LLM to start negotiating for and then purchase the research
+  const result = await generateText({
+    model: openai("gpt-4o"),
+    stopWhen: stepCountIs(3),
+    messages,
+    tools: {
+      createPaymentRequest: tool({
+        description: "Create a payment request",
+        inputSchema: z.object({
+          productId: z.string().describe("ID of the product to purchase"),
+          amount: z.number().describe("Amount of the payment request in USD"),
+          description: z.string().describe("Description of the payment request")
+        }),
+
+        execute: async ({ amount, description, productId }) => {
+          const product = products.find((product) => product.id === productId)
+
+          if (!product) {
+            return {
+              state: "error",
+              message: "Product not found"
+            }
+          }
+
+          //each time we create a PRT, we will store it in the database so that when we receive a receipt
+          //we can validate that it was for a payment request created by us
+          const prt = await db
+            .insert(paymentRequestsTable)
+            .values({
+              price: amount,
+              metadata: { productId: product.id }
+            })
+            .returning()
+
+          //now create the payment request itself using the ACK Lab SDK
+          const paymentRequest = await sdk.createPaymentRequest({
+            description: description,
+            amount: amount * 100,
+            currencyCode: "USD",
+            id: prt[0].id
+          })
+          paymentRequestToken = paymentRequest.paymentRequestToken
+
+          console.log("Payment Request Token generated")
+          console.log(paymentRequestToken)
+
+          return "Payment Request token created"
+        }
+      })
+    }
+  })
+
+  return {
+    message: result.text,
+    paymentRequestToken
+  }
+}
+
+// Create an agent handler that will process incoming messages
+// This uses the ACK Lab SDK to provide a secure communication channel between the buyer and the seller
+export const handler = sdk.createRequestHandler(inputSchema, processMessage)

--- a/examples/paywall/app/api/chat/negotiate/route.ts
+++ b/examples/paywall/app/api/chat/negotiate/route.ts
@@ -1,0 +1,11 @@
+import { handler } from "./agent"
+
+// This is the endpoint that the buyer will call to purchase research
+// Almost all of the actual work is delegated to the processMessage function in negotiating-agent.ts
+export async function POST(req: Request) {
+  const body = await req.json()
+
+  const response = await handler(body.jwt)
+
+  return new Response(JSON.stringify(response))
+}


### PR DESCRIPTION
Builds on https://github.com/catena-labs/ack-lab-sdk/pull/25 and https://github.com/catena-labs/ack-lab-sdk/pull/26, introducing chat-based payments.

Introduces a buyer-side example for the buying an item for a fixed price via our SDK messaging channel but not using an LLM:

`pnpm run buy-chat-fixed-price`

And one that does the same, but triggered via an LLM tool call:

`pnpm run buy-chat-llm`

And one that negotiates (the negotiate agent source was added as part of https://github.com/catena-labs/ack-lab-sdk/pull/25):

`pnpm run negotiate`