### PR TITLE
Agent ID and Org-level auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,68 @@ npm install @ack-lab/sdk
 
 ## Quick Start
 
+### Single Agent
+
+When you have a single ACK Lab Agent to control, you can use the `AckLabAgent` class to create an Agent instance:
+
 ```ts
 import { AckLabAgent } from "@ack-lab/sdk"
-import * as v from "valibot" // or any Standard Schema compliant library
 
+// Create an agent instance with your client ID, secret, and agent ID
 const agent = new AckLabAgent({
   clientId: "your-client-id",
   clientSecret: "your-client-secret",
   agentId: "your-agent-id"
 })
+
+// Generate a request for our agent to get paid
+const paymentRequest = await agent.createPaymentRequest({
+  id: crypto.randomUUID(),
+  amount: 100,
+  currencyCode: "USD",
+  description: "Service fee"
+})
+
+// Send the payment request token to the other agent
+...
 ```
 
 See an example of using this SDK in [./src/demo/addition-demo.ts](./src/demo/addition-demo.ts).
 
 To create your Client ID & Secret, sign up for a free account at [ACK-Lab](https://ack-lab.catenalabs.com). Create an Agent in the dashboard, copy the agent ID from the URL, and create a Client ID & Secret in the API Keys tab.
+
+### Multiple Agents
+
+When you have multiple ACK Lab Agents to control, use an organization-level API key and the `AckLabSdk` class to create an SDK instance that can create and control multiple Agents:
+
+```ts
+import { AckLabSdk } from "@ack-lab/sdk"
+
+// The SDK instance can be used to control multiple agents in the same organization
+const sdk = new AckLabSdk({
+  clientId: "your-client-id",
+  clientSecret: "your-client-secret"
+})
+
+// We do not need to pass in the client ID and secret each time
+const agent = sdk.agent({ agentId: "first-agent-id" })
+const otherAgent = sdk.agent({ agentId: "second-agent-id" })
+
+const paymentRequest = await agent.createPaymentRequest({
+  id: crypto.randomUUID(),
+  amount: 100,
+  currencyCode: "USD",
+  description: "Service fee"
+})
+
+const result = await otherAgent.executePayment(
+  paymentRequest.paymentRequestToken
+)
+
+const { receipt, paymentRequestId } = await agent.verifyPaymentReceipt(
+  result.receipt
+)
+```
 
 ## Usage
 
@@ -124,7 +172,7 @@ Check out the [examples README](./examples/README.md) to find out more and run t
 ### Constructor
 
 ```ts
-new AckLabAgent(config: ApiClientConfig, opts?: { resolver?: Resolvable })
+new AckLabAgent(config: AckLabAgentConfig, opts?: { resolver?: Resolvable })
 ```
 
 Create a new agent instance with your client credentials.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 TypeScript SDK for the [ACK-Lab](https://ack-lab.catenalabs.com) Developer Preview.
 
+ACK-Lab is an experimental online service that makes it easy to research and test agentic payments using stablecoins. The service implements the [Agentic Commerce Kit (ACK)](https://www.agentcommercekit.com/) protocol and patterns.
+
 ## Installation
 
 ```bash
@@ -11,31 +13,126 @@ npm install @ack-lab/sdk
 ## Quick Start
 
 ```ts
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import * as v from "valibot" // or any Standard Schema compliant library
 
-const sdk = new AckLabSdk({
+const agent = new AckLabAgent({
   clientId: "your-client-id",
-  clientSecret: "your-client-secret"
+  clientSecret: "your-client-secret",
+  agentId: "your-agent-id"
 })
 ```
 
 See an example of using this SDK in [./src/demo/addition-demo.ts](./src/demo/addition-demo.ts).
+
+To create your Client ID & Secret, sign up for a free account at [ACK-Lab](https://ack-lab.catenalabs.com). Create an Agent in the dashboard, copy the agent ID from the URL, and create a Client ID & Secret in the API Keys tab.
+
+## Usage
+
+The ACK Lab SDK offers a collection of agent-centric actions that can be performed using the `AckLabAgent` class:
+
+- Requesting Payments from other Agents
+- Making Payments to other Agents
+- Exchanging secure messages and data with other Agents
+- Verifying Payment Receipts from other Agents
+
+### Payments
+
+An Agent can generate a payment request token that can be sent to another agent:
+
+```ts
+const paymentRequest = await agent.createPaymentRequest({
+  id: crypto.randomUUID(),
+  amount: 100,
+  currencyCode: "USD",
+  description: "Service fee"
+})
+```
+
+The payment request token can then be sent to another agent, who can execute it using the `executePayment` method:
+
+```ts
+const result = await otherAgent.executePayment(paymentRequestToken)
+```
+
+The result will contain the payment receipt, which can be verified by the agent who made the payment request using the `verifyPaymentReceipt` method:
+
+```ts
+try {
+  const { receipt, paymentRequestId } = await agent.verifyPaymentReceipt(
+    result.receipt
+  )
+} catch (e) {
+  console.error("Failed to verify payment receipt:", e)
+}
+
+// paymentRequestId can be used to look up the payment request in your database
+// and deliver the purchased goods/services to the buyer
+```
+
+### Messaging
+
+The SDK also provides a secure messaging channel to allow LLMs on either side of a payment to exchange messages and data, simply by supplying an HTTP endpoint that the message will be sent to.
+
+Under the covers, the function returned by `createAgentCaller` uses ACK and ACK Lab to securely perform an exchange of Verifiable Presentations between the two agents during an initial handshake process. This process verifies the identity of both agents and establishes a secure channel for subsequent messages. This happens transparently and is handled automatically by the ACK Lab SDK:
+
+```ts
+const sendMessage = agent.createAgentCaller(
+  "https://some-chatty-bot.ai/chat",
+  v.string(),
+  v.string()
+)
+const response = await sendMessage("Hello!")
+
+// after the initial handshake and the message has been sent, we're expecting this response to be "Echo: Hello!"
+console.log(response)
+```
+
+The `/chat` endpoint above could look something like this, using `createRequestHandler` - the mirror of `createAgentCaller` - to automatically handle the secure reception of messages from the initiating agent:
+
+```ts
+// create an ACK Lab agent instance for the echo agent
+const echoAgent = new AckLabAgent({
+  clientId: "echo-agent-org-client-id",
+  clientSecret: "echo-agent-org-client-secret",
+  agentId: "echo-agent-id-from-ack-lab"
+})
+
+// this entire endpoint is just something that accepts a message and echoes it back
+const handler = echoAgent.createRequestHandler(v.string(), async (message) => {
+  return `Echo: ${message}`
+})
+
+// Use with your HTTP server
+app.post("/chat", async (req, res) => {
+  const { jwt } = req.body
+  const response = await handler(jwt)
+  res.json(response)
+})
+```
+
+See the [buy-chat-fixed-price example](./examples/buyer) for an example where we send back structured data as well as text messages, allowing LLMs to respond flexibly.
+
+### Examples
+
+The SDK ships with a set of buy-side and sell-side examples, which you can find in the examples directory. The examples demonstrate a variety of payment patterns, from simple one-off payments through to AI-negotiated deals.
+
+Check out the [examples README](./examples/README.md) to find out more and run the examples yourself.
 
 ## Methods
 
 ### Constructor
 
 ```ts
-new AckLabSdk(config: ApiClientConfig, opts?: { resolver?: Resolvable })
+new AckLabAgent(config: ApiClientConfig, opts?: { resolver?: Resolvable })
 ```
 
-Create a new SDK instance with your client credentials.
+Create a new agent instance with your client credentials.
 
 ### createAgentCaller(url: string, inputSchema: Schema, outputSchema: Schema)
 
 ```ts
-const callAgent = sdk.createAgentCaller(
+const callAgent = agent.createAgentCaller(
   "http://localhost:3000/chat",
   v.object({ message: v.string() }),
   v.string()
@@ -50,7 +147,7 @@ The schema parameters accept any [Standard Schema](https://standardschema.dev/) 
 ### createRequestHandler(schema: Schema, handler: HandlerFn)
 
 ```ts
-const handler = sdk.createRequestHandler(
+const handler = agent.createRequestHandler(
   v.object({ message: v.string() }),
   async (input) => {
     return `Echo: ${input.message}`
@@ -72,7 +169,7 @@ The schema parameter accepts any [Standard Schema](https://standardschema.dev/) 
 ### createPaymentRequest(params: { id?: string, amount: number, currencyCode?: string, description?: string })
 
 ```ts
-const paymentRequest = await sdk.createPaymentRequest({
+const paymentRequest = await agent.createPaymentRequest({
   id: crypto.randomUUID(),
   amount: 100,
   currencyCode: "USD",
@@ -85,7 +182,7 @@ Creates a payment request for the specified amount, in minor units (e.g. cents f
 ### executePayment(paymentRequestToken: string)
 
 ```ts
-const result = await sdk.executePayment(paymentRequestToken)
+const result = await agent.executePayment(paymentRequestToken)
 ```
 
 Executes a payment using the provided payment request token.
@@ -94,7 +191,7 @@ Executes a payment using the provided payment request token.
 
 ```ts
 const { receipt, paymentRequestId } =
-  await sdk.verifyPaymentReceipt(receiptString)
+  await agent.verifyPaymentReceipt(receiptString)
 ```
 
 Verifies a payment receipt and returns the verified receipt along with the associated payment request ID.

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,34 +59,34 @@ The `buyer` directory contains 5 runnable examples demonstrating different inter
 
 ### `pnpm run buy-fixed-price`
 
-**What it does**: Purchases a digital product using direct HTTP requests to the simplest paywall endpoint.
-**Paywall side**: Uses `/api/fixed-price` - the most basic ACK Lab SDK implementation
-**Flow**: Makes HTTP POST → receives PRT → pays → submits receipt → gets digital content
-**Learn more**: [Fixed-Price README](paywall/app/api/fixed-price/README.md)
+- **What it does**: Purchases a digital product using direct HTTP requests to the simplest paywall endpoint.
+- **Paywall side**: Uses `/api/fixed-price` - the most basic ACK Lab SDK implementation
+- **Flow**: Makes HTTP POST → receives PRT → pays → submits receipt → gets digital content
+- **Learn more**: [Fixed-Price README](paywall/app/api/fixed-price/README.md)
 
 ### `pnpm run buy-chat-fixed-price`
 
-**What it does**: Purchases research through secure agent-to-agent communication at a fixed price.
-**Paywall side**: Uses `/api/chat/fixed-price` - conversational commerce with agent messaging
-**Flow**: Sends agent message → receives PRT → pays → sends receipt via agent → gets research
-**Learn more**: [Fixed-Price Chat README](paywall/app/api/chat/fixed-price/README.md)
+- **What it does**: Purchases research through secure agent-to-agent communication at a fixed price.
+- **Paywall side**: Uses `/api/chat/fixed-price` - conversational commerce with agent messaging
+- **Flow**: Sends agent message → receives PRT → pays → sends receipt via agent → gets research
+- **Learn more**: [Fixed-Price Chat README](paywall/app/api/chat/fixed-price/README.md)
 
 ### `pnpm run negotiate`
 
-**What it does**: Demonstrates AI-vs-AI negotiation where both buyer and seller agents negotiate autonomously.
-**Paywall side**: Uses `/api/chat/negotiate` - AI-powered price negotiation with business constraints
-**Flow**: AI agents negotiate → price agreed → payment executed → receipt submitted → research delivered
-**Learn more**: [Negotiation Chat README](paywall/app/api/chat/negotiate/README.md)
+- **What it does**: Demonstrates AI-vs-AI negotiation where both buyer and seller agents negotiate autonomously.
+- **Paywall side**: Uses `/api/chat/negotiate` - AI-powered price negotiation with business constraints
+- **Flow**: AI agents negotiate → price agreed → payment executed → receipt submitted → research delivered
+- **Learn more**: [Negotiation Chat README](paywall/app/api/chat/negotiate/README.md)
 
 ### `pnpm run images`
 
-**What it does**: Complete credit-based workflow - purchases image credits, then generates and saves president images.
-**Paywall side**: Uses both `/api/images/buy` and `/api/images/generate` - credit purchase and consumption
-**Flow**: Buys 3 credits → pays PRT → generates 2 images → saves to `./images/` directory
-**Learn more**: [Image Credits README](paywall/app/api/images/buy/README.md) and [Image Generation README](paywall/app/api/images/generate/README.md)
+- **What it does**: Complete credit-based workflow - purchases image credits, then generates and saves president images.
+- **Paywall side**: Uses both `/api/images/buy` and `/api/images/generate` - credit purchase and consumption
+- **Flow**: Buys 3 credits → pays PRT → generates 2 images → saves to `./images/` directory
+- **Learn more**: [Image Credits README](paywall/app/api/images/buy/README.md) and [Image Generation README](paywall/app/api/images/generate/README.md)
 
 ### `pnpm run buy-chat-llm`
 
-**What it does**: Uses an LLM-powered buyer agent to interact with seller endpoints (implementation varies).
-**Paywall side**: Can interact with various chat endpoints depending on implementation
-**Flow**: LLM-driven buyer behavior with autonomous decision making
+- **What it does**: Uses an LLM-powered buyer agent to interact with seller endpoints (implementation varies).
+- **Paywall side**: Can interact with various chat endpoints depending on implementation
+- **Flow**: LLM-driven buyer behavior with autonomous decision making

--- a/examples/buyer/README.md
+++ b/examples/buyer/README.md
@@ -33,7 +33,7 @@ Start the paywall server first (`cd ../paywall && pnpm dev`) or use the live ins
 - Makes POST to `/api/fixed-price` with empty body
 - Receives 402 status with Payment Request Token
 - Validates PRT amount using `verifyPaymentRequestToken()`
-- Executes payment with `sdk.executePayment()`
+- Executes payment with `agent.executePayment()`
 - Makes second POST with receipt to get digital product
 
 **Key techniques**: Direct HTTP requests, PRT validation, receipt submission
@@ -64,7 +64,7 @@ Start the paywall server first (`cd ../paywall && pnpm dev`) or use the live ins
 - Creates `AgentCaller` with request/response schemas using Valibot
 - Sends structured message: `{message: "Hello I would like to buy research on William Adama"}`
 - Receives response with `paymentRequestToken`
-- Executes payment using `sdk.executePayment()`
+- Executes payment using `agent.executePayment()`
 - Sends second message with receipt: `{message: "...", receipt}`
 - Receives research content in structured response
 
@@ -91,7 +91,7 @@ Start the paywall server first (`cd ../paywall && pnpm dev`) or use the live ins
 **Under the covers**:
 
 - **Buyer AI**: GPT-4o with negotiation strategy (target: $15 or less)
-- **Communication**: Uses `sdk.createAgentCaller()` for secure messaging
+- **Communication**: Uses `agent.createAgentCaller()` for secure messaging
 - **Negotiation loop**: LLM calls `buyResearch` tool repeatedly until agreement
 - **Price validation**: Validates PRT amounts using `verifyPaymentRequestToken()`
 - **Decision logic**: Accepts offers below $20 (full price), continues negotiating otherwise

--- a/examples/buyer/scripts/buy-chat-fixed-price.ts
+++ b/examples/buyer/scripts/buy-chat-fixed-price.ts
@@ -8,7 +8,7 @@ import * as v from "valibot"
 
 config()
 
-const sdk = new AckLabAgent({
+const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
   agentId: process.env.ACK_LAB_AGENT_ID!,
@@ -30,7 +30,7 @@ const responseSchema = v.object({
   research: v.optional(v.string())
 })
 
-const callAgent = sdk.createAgentCaller(
+const callAgent = agent.createAgentCaller(
   `${process.env.PAYWALL_HOST}/api/chat/fixed-price`,
   requestSchema,
   responseSchema
@@ -51,7 +51,7 @@ async function main() {
   console.log(paymentRequestToken)
 
   console.log("\n\nExecuting payment...")
-  const { receipt } = await sdk.executePayment(paymentRequestToken)
+  const { receipt } = await agent.executePayment(paymentRequestToken)
 
   console.log("\n\nPayment made, sending receipt to seller...")
   console.log(receipt)

--- a/examples/buyer/scripts/buy-chat-fixed-price.ts
+++ b/examples/buyer/scripts/buy-chat-fixed-price.ts
@@ -11,8 +11,7 @@ config()
 const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
-  agentId: process.env.ACK_LAB_AGENT_ID!,
-  baseUrl: process.env.ACK_LAB_BASE_URL!
+  agentId: process.env.ACK_LAB_AGENT_ID!
 })
 
 // When our agent sends messages to the counterparty agent, the messages are of this shape

--- a/examples/buyer/scripts/buy-chat-fixed-price.ts
+++ b/examples/buyer/scripts/buy-chat-fixed-price.ts
@@ -3,14 +3,16 @@
  * Use with value bearing assets or outside the test environment may result in permanent loss of value.
  */
 import { config } from "dotenv"
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import * as v from "valibot"
 
 config()
 
-const sdk = new AckLabSdk({
+const sdk = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+  agentId: process.env.ACK_LAB_AGENT_ID!,
+  baseUrl: process.env.ACK_LAB_BASE_URL!
 })
 
 // When our agent sends messages to the counterparty agent, the messages are of this shape

--- a/examples/buyer/scripts/buy-fixed-price.ts
+++ b/examples/buyer/scripts/buy-fixed-price.ts
@@ -3,14 +3,16 @@
  * Use with value bearing assets or outside the test environment may result in permanent loss of value.
  */
 import { config } from "dotenv"
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import { verifyPaymentRequestToken, getDidResolver } from "agentcommercekit"
 
 config()
 
-const sdk = new AckLabSdk({
+const sdk = new AckLabAgent({
+  baseUrl: process.env.ACK_LAB_BASE_URL!,
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+  agentId: process.env.ACK_LAB_AGENT_ID!
 })
 
 const endpoint = `${process.env.PAYWALL_HOST}/api/fixed-price`

--- a/examples/buyer/scripts/buy-fixed-price.ts
+++ b/examples/buyer/scripts/buy-fixed-price.ts
@@ -8,7 +8,7 @@ import { verifyPaymentRequestToken, getDidResolver } from "agentcommercekit"
 
 config()
 
-const sdk = new AckLabAgent({
+const agent = new AckLabAgent({
   baseUrl: process.env.ACK_LAB_BASE_URL!,
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
@@ -49,7 +49,7 @@ async function main() {
   }
 
   console.log("\n\nExecuting payment...")
-  const { receipt } = await sdk.executePayment(paymentRequestToken)
+  const { receipt } = await agent.executePayment(paymentRequestToken)
 
   console.log("Payment made, sending receipt to seller...")
   console.log(receipt)

--- a/examples/buyer/scripts/buy-fixed-price.ts
+++ b/examples/buyer/scripts/buy-fixed-price.ts
@@ -9,7 +9,6 @@ import { verifyPaymentRequestToken, getDidResolver } from "agentcommercekit"
 config()
 
 const agent = new AckLabAgent({
-  baseUrl: process.env.ACK_LAB_BASE_URL!,
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
   agentId: process.env.ACK_LAB_AGENT_ID!

--- a/examples/buyer/scripts/images.ts
+++ b/examples/buyer/scripts/images.ts
@@ -13,8 +13,7 @@ config()
 const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
-  agentId: process.env.ACK_LAB_AGENT_ID!,
-  baseUrl: process.env.ACK_LAB_BASE_URL!
+  agentId: process.env.ACK_LAB_AGENT_ID!
 })
 
 const purchaseEndpoint = `${process.env.PAYWALL_HOST}/api/images/buy`

--- a/examples/buyer/scripts/images.ts
+++ b/examples/buyer/scripts/images.ts
@@ -3,16 +3,18 @@
  * Use with value bearing assets or outside the test environment may result in permanent loss of value.
  */
 import { config } from "dotenv"
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import { verifyPaymentRequestToken, getDidResolver } from "agentcommercekit"
 import { presidents } from "../data/presidents"
 import fs, { mkdirSync } from "fs"
 
 config()
 
-const sdk = new AckLabSdk({
+const sdk = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+  agentId: process.env.ACK_LAB_AGENT_ID!,
+  baseUrl: process.env.ACK_LAB_BASE_URL!
 })
 
 const purchaseEndpoint = `${process.env.PAYWALL_HOST}/api/images/buy`

--- a/examples/buyer/scripts/images.ts
+++ b/examples/buyer/scripts/images.ts
@@ -10,7 +10,7 @@ import fs, { mkdirSync } from "fs"
 
 config()
 
-const sdk = new AckLabAgent({
+const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
   agentId: process.env.ACK_LAB_AGENT_ID!,
@@ -55,7 +55,7 @@ async function main() {
   }
 
   console.log("\n\nExecuting payment...")
-  const { receipt } = await sdk.executePayment(paymentRequestToken)
+  const { receipt } = await agent.executePayment(paymentRequestToken)
 
   console.log("Payment made, generating images...")
 

--- a/examples/buyer/scripts/negotiate.ts
+++ b/examples/buyer/scripts/negotiate.ts
@@ -11,7 +11,8 @@ async function main() {
 
   const agent = new NegotiatingBuyerAgent({
     clientId: process.env.ACK_LAB_CLIENT_ID!,
-    clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+    clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+    agentId: process.env.ACK_LAB_AGENT_ID!
   })
 
   const research = await agent.purchaseResearch(name)

--- a/examples/buyer/src/buy-agent.ts
+++ b/examples/buyer/src/buy-agent.ts
@@ -25,7 +25,7 @@ const responseSchema = v.object({
 })
 
 export class ResearchPurchasingAgent {
-  sdk: AckLabAgent
+  agent: AckLabAgent
   callAgent
 
   constructor({
@@ -35,14 +35,14 @@ export class ResearchPurchasingAgent {
     clientId: string
     clientSecret: string
   }) {
-    this.sdk = new AckLabAgent({
+    this.agent = new AckLabAgent({
       clientId,
       clientSecret,
       agentId: process.env.ACK_LAB_AGENT_ID!,
       baseUrl: process.env.ACK_LAB_BASE_URL!
     })
 
-    this.callAgent = this.sdk.createAgentCaller(
+    this.callAgent = this.agent.createAgentCaller(
       `${process.env.PAYWALL_HOST}/api/chat/fixed-price`,
       requestSchema,
       responseSchema
@@ -83,7 +83,7 @@ export class ResearchPurchasingAgent {
 
               console.log("\n\nExecuting payment...")
               const { receipt } =
-                await this.sdk.executePayment(paymentRequestToken)
+                await this.agent.executePayment(paymentRequestToken)
 
               console.log("\n\nPayment made, here is the receipt:")
               console.log(receipt)

--- a/examples/buyer/src/buy-agent.ts
+++ b/examples/buyer/src/buy-agent.ts
@@ -38,8 +38,7 @@ export class ResearchPurchasingAgent {
     this.agent = new AckLabAgent({
       clientId,
       clientSecret,
-      agentId: process.env.ACK_LAB_AGENT_ID!,
-      baseUrl: process.env.ACK_LAB_BASE_URL!
+      agentId: process.env.ACK_LAB_AGENT_ID!
     })
 
     this.callAgent = this.agent.createAgentCaller(

--- a/examples/buyer/src/buy-agent.ts
+++ b/examples/buyer/src/buy-agent.ts
@@ -2,8 +2,7 @@
  * Simplified example code for ACK Lab Developer Preview use only. For use in test environment only.
  * Use with value bearing assets or outside the test environment may result in permanent loss of value.
  */
-
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 
 import { generateText, tool, stepCountIs } from "ai"
 import { openai } from "@ai-sdk/openai"
@@ -26,7 +25,7 @@ const responseSchema = v.object({
 })
 
 export class ResearchPurchasingAgent {
-  sdk: AckLabSdk
+  sdk: AckLabAgent
   callAgent
 
   constructor({
@@ -36,9 +35,11 @@ export class ResearchPurchasingAgent {
     clientId: string
     clientSecret: string
   }) {
-    this.sdk = new AckLabSdk({
+    this.sdk = new AckLabAgent({
       clientId,
-      clientSecret
+      clientSecret,
+      agentId: process.env.ACK_LAB_AGENT_ID!,
+      baseUrl: process.env.ACK_LAB_BASE_URL!
     })
 
     this.callAgent = this.sdk.createAgentCaller(

--- a/examples/buyer/src/buy-agent.ts
+++ b/examples/buyer/src/buy-agent.ts
@@ -8,6 +8,7 @@ import { generateText, tool, stepCountIs } from "ai"
 import { openai } from "@ai-sdk/openai"
 import { z } from "zod"
 import * as v from "valibot"
+import { logToolErrors } from "./utils/log-tool-errors"
 
 // When our agent sends messages to the counterparty agent, the messages are of this shape
 // There is always a message, and sometimes a receipt
@@ -51,7 +52,7 @@ export class ResearchPurchasingAgent {
   async purchaseResearch(name: string) {
     let researchResult: string | undefined
 
-    await generateText({
+    const { steps } = await generateText({
       model: openai("gpt-4o"),
       stopWhen: stepCountIs(10),
       tools: {
@@ -112,6 +113,8 @@ export class ResearchPurchasingAgent {
         }
       ]
     })
+
+    logToolErrors(steps)
 
     return researchResult
   }

--- a/examples/buyer/src/negotiate.ts
+++ b/examples/buyer/src/negotiate.ts
@@ -2,7 +2,7 @@
  * Simplified example code for ACK Lab Developer Preview use only. For use in test environment only.
  * Use with value bearing assets or outside the test environment may result in permanent loss of value.
  */
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import { verifyPaymentRequestToken, getDidResolver } from "agentcommercekit"
 
 import { generateText, tool, stepCountIs } from "ai"
@@ -43,7 +43,7 @@ try to see if you can get a little more discount, but accept the first discount 
 if the seller remains firm on that.`
 
 export class NegotiatingBuyerAgent {
-  sdk: AckLabSdk
+  sdk: AckLabAgent
   messages: ModelMessage[]
   callAgent
   sessionId?: string
@@ -55,9 +55,11 @@ export class NegotiatingBuyerAgent {
     clientId: string
     clientSecret: string
   }) {
-    this.sdk = new AckLabSdk({
+    this.sdk = new AckLabAgent({
       clientId,
-      clientSecret
+      clientSecret,
+      agentId: process.env.ACK_LAB_AGENT_ID!,
+      baseUrl: process.env.ACK_LAB_BASE_URL!
     })
 
     this.messages = [

--- a/examples/buyer/src/negotiate.ts
+++ b/examples/buyer/src/negotiate.ts
@@ -43,7 +43,7 @@ try to see if you can get a little more discount, but accept the first discount 
 if the seller remains firm on that.`
 
 export class NegotiatingBuyerAgent {
-  sdk: AckLabAgent
+  agent: AckLabAgent
   messages: ModelMessage[]
   callAgent
   sessionId?: string
@@ -55,7 +55,7 @@ export class NegotiatingBuyerAgent {
     clientId: string
     clientSecret: string
   }) {
-    this.sdk = new AckLabAgent({
+    this.agent = new AckLabAgent({
       clientId,
       clientSecret,
       agentId: process.env.ACK_LAB_AGENT_ID!,
@@ -69,7 +69,7 @@ export class NegotiatingBuyerAgent {
       }
     ]
 
-    this.callAgent = this.sdk.createAgentCaller(
+    this.callAgent = this.agent.createAgentCaller(
       `${process.env.PAYWALL_HOST}/api/chat/negotiate`,
       requestSchema,
       responseSchema
@@ -150,7 +150,7 @@ export class NegotiatingBuyerAgent {
                 "\n\nwe have reached a price agreement, execute the payment"
               )
               //we have reached a price agreement, execute the payment
-              const { receipt } = await this.sdk.executePayment(
+              const { receipt } = await this.agent.executePayment(
                 negotiation.paymentRequestToken
               )
 

--- a/examples/buyer/src/negotiate.ts
+++ b/examples/buyer/src/negotiate.ts
@@ -58,8 +58,7 @@ export class NegotiatingBuyerAgent {
     this.agent = new AckLabAgent({
       clientId,
       clientSecret,
-      agentId: process.env.ACK_LAB_AGENT_ID!,
-      baseUrl: process.env.ACK_LAB_BASE_URL!
+      agentId: process.env.ACK_LAB_AGENT_ID!
     })
 
     this.messages = [

--- a/examples/buyer/src/utils/log-tool-errors.ts
+++ b/examples/buyer/src/utils/log-tool-errors.ts
@@ -1,0 +1,13 @@
+import type { StepResult } from "ai"
+
+// In the Vercel AI SDK, tools can be retried so we don't get an visible error shown if something
+// went wrong unless we log the tool errors ourselves
+export function logToolErrors(steps: StepResult<any>[]) {
+  const toolErrors = steps.flatMap((s) =>
+    s.content.filter((p) => p.type === "tool-error")
+  )
+  if (toolErrors.length) {
+    console.log("Encountered tool errors:")
+    console.log(toolErrors)
+  }
+}

--- a/examples/paywall/README.md
+++ b/examples/paywall/README.md
@@ -47,46 +47,46 @@ Each endpoint can be tested using corresponding buyer scripts from the `../buyer
 
 The most basic ACK Lab SDK implementation - handles both payment requests and product delivery in a single endpoint.
 
-**How it works**: Direct HTTP POST requests without agent communication
-**Pattern**: Fixed-price digital product sales
-**Buyer script**: `cd ../buyer && pnpm run buy-fixed-price`
-**Details**: [Fixed-Price README](app/api/fixed-price/README.md)
+- **How it works**: Direct HTTP POST requests without agent communication
+- **Pattern**: Fixed-price digital product sales
+- **Buyer script**: `cd ../buyer && pnpm run buy-fixed-price`
+- **Details**: [Fixed-Price README](app/api/fixed-price/README.md)
 
 ### `/api/chat/fixed-price` - Conversational Fixed-Price Sales
 
 Demonstrates secure agent-to-agent communication for selling research at a fixed price.
 
-**How it works**: Uses ACK Lab's secure messaging with structured schemas
-**Pattern**: Conversational commerce with agent communication
-**Buyer script**: `cd ../buyer && pnpm run buy-chat-fixed-price`
-**Details**: [Fixed-Price Chat README](app/api/chat/fixed-price/README.md)
+- **How it works**: Uses ACK Lab's secure messaging with structured schemas
+- **Pattern**: Conversational commerce with agent communication
+- **Buyer script**: `cd ../buyer && pnpm run buy-chat-fixed-price`
+- **Details**: [Fixed-Price Chat README](app/api/chat/fixed-price/README.md)
 
 ### `/api/chat/negotiate` - AI-Powered Price Negotiation
 
 Shows autonomous AI agents negotiating prices within business constraints using GPT-4o.
 
-**How it works**: LLM-driven negotiation with autonomous payment request creation
-**Pattern**: AI-vs-AI price negotiation with business rules
-**Buyer script**: `cd ../buyer && pnpm run negotiate`
-**Details**: [Negotiation Chat README](app/api/chat/negotiate/README.md)
+- **How it works**: LLM-driven negotiation with autonomous payment request creation
+- **Pattern**: AI-vs-AI price negotiation with business rules
+- **Buyer script**: `cd ../buyer && pnpm run negotiate`
+- **Details**: [Negotiation Chat README](app/api/chat/negotiate/README.md)
 
 ### `/api/images/buy` - Credit-Based Purchasing
 
 Implements bulk credit purchasing where buyers pre-pay for image generation rights.
 
-**How it works**: Variable quantity purchasing with metadata tracking
-**Pattern**: Credit-based commerce with bulk purchasing
-**Buyer script**: `cd ../buyer && pnpm run images` (uses both buy and generate)
-**Details**: [Image Credits Purchase README](app/api/images/buy/README.md)
+- **How it works**: Variable quantity purchasing with metadata tracking
+- **Pattern**: Credit-based commerce with bulk purchasing
+- **Buyer script**: `cd ../buyer && pnpm run images` (uses both buy and generate)
+- **Details**: [Image Credits Purchase README](app/api/images/buy/README.md)
 
 ### `/api/images/generate` - Credit Consumption Service
 
 Consumes purchased credits to generate AI images using DALL-E 3, with usage tracking.
 
-**How it works**: Credit validation, AI image generation, and credit consumption
-**Pattern**: Pay-per-use service with credit tracking
-**Buyer script**: `cd ../buyer && pnpm run images` (uses both buy and generate)
-**Details**: [Image Generation README](app/api/images/generate/README.md)
+- **How it works**: Credit validation, AI image generation, and credit consumption
+- **Pattern**: Pay-per-use service with credit tracking
+- **Buyer script**: `cd ../buyer && pnpm run images` (uses both buy and generate)
+- **Details**: [Image Generation README](app/api/images/generate/README.md)
 
 ## Prerequisites
 
@@ -134,7 +134,7 @@ All endpoints store payment requests in the database before creating ACK Lab pay
 // Store first
 const prt = await db.insert(paymentRequestsTable).values({...}).returning()
 // Then create with ACK Lab
-const { paymentRequestToken } = await sdk.createPaymentRequest({id: prt[0].id})
+const { paymentRequestToken } = await agent.createPaymentRequest({id: prt[0].id})
 ```
 
 ### Receipt Validation
@@ -143,7 +143,7 @@ Two-step verification ensures security:
 
 ```typescript
 // 1. Cryptographic verification
-const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+const { paymentRequestId } = await agent.verifyPaymentReceipt(receipt)
 // 2. Database verification
 const prt = await getDbPaymentRequest(paymentRequestId)
 ```
@@ -153,7 +153,7 @@ const prt = await getDbPaymentRequest(paymentRequestId)
 Chat endpoints use structured messaging:
 
 ```typescript
-export const handler = sdk.createRequestHandler(inputSchema, processMessage)
+export const handler = agent.createRequestHandler(inputSchema, processMessage)
 ```
 
 ## Security Features

--- a/examples/paywall/app/api/chat/fixed-price/README.md
+++ b/examples/paywall/app/api/chat/fixed-price/README.md
@@ -34,7 +34,7 @@ const prt = await db
   .returning()
 
 // Create the payment request using ACK Lab SDK
-const { paymentRequestToken } = await sdk.createPaymentRequest({
+const { paymentRequestToken } = await agent.createPaymentRequest({
   description: `Purchase ${product.title}`,
   amount: product.price * 100, // Amount in cents
   currencyCode: "USD",
@@ -55,7 +55,7 @@ After the buyer pays using the PRT, they receive a receipt which they can submit
 ```typescript
 if (receipt) {
   // Verify the receipt is cryptographically valid
-  const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+  const { paymentRequestId } = await agent.verifyPaymentReceipt(receipt)
 
   // Check that we actually created this payment request
   const prt = await getDbPaymentRequest(paymentRequestId)
@@ -74,7 +74,7 @@ if (receipt) {
 
 **Why we do this:**
 
-- `sdk.verifyPaymentReceipt()` cryptographically validates that the receipt is authentic and hasn't been tampered with
+- `agent.verifyPaymentReceipt()` cryptographically validates that the receipt is authentic and hasn't been tampered with
 - Checking our database ensures we only deliver products for payments we actually requested - this prevents replay attacks where someone might try to use a valid receipt from a different merchant
 - The two-step verification (cryptographic + database lookup) provides strong security guarantees
 
@@ -107,7 +107,7 @@ const outputSchema = v.object({
 The ACK Lab SDK provides a request handler that manages the secure communication:
 
 ```typescript
-export const handler = sdk.createRequestHandler(inputSchema, processMessage)
+export const handler = agent.createRequestHandler(inputSchema, processMessage)
 ```
 
 **Why we do this:**
@@ -138,7 +138,7 @@ This allows tracking of:
 
 ## Security Considerations
 
-1. **Receipt Validation**: Always verify receipts cryptographically using `sdk.verifyPaymentReceipt()`
+1. **Receipt Validation**: Always verify receipts cryptographically using `agent.verifyPaymentReceipt()`
 2. **Payment Request Verification**: Check that receipts correspond to payment requests you actually created
 3. **Database Integrity**: Store payment request details before creating the ACK Lab payment request
 4. **Error Handling**: Fail securely when receipts don't match your records
@@ -162,7 +162,7 @@ The buyer agent (`buyer/scripts/buy-chat-fixed-price.ts`) implements:
 
 1. Sends initial message requesting research on William Adama
 2. Receives payment request token from the seller
-3. Executes payment using `sdk.executePayment()`
+3. Executes payment using `agent.executePayment()`
 4. Submits receipt back to seller with the same message
 5. Receives and displays the purchased research content
 

--- a/examples/paywall/app/api/chat/fixed-price/agent.ts
+++ b/examples/paywall/app/api/chat/fixed-price/agent.ts
@@ -2,7 +2,7 @@
  * Simplified example code for ACK Lab Developer Preview use only. For use in test environment only.
  * Use with value bearing assets or outside the test environment may result in permanent loss of value.
  */
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import * as v from "valibot"
 import { getDbPaymentRequest } from "@/db/queries/payment-requests"
 import { db } from "@/db"
@@ -34,9 +34,11 @@ const _outputSchema = v.object({
 
 type Output = v.InferOutput<typeof _outputSchema>
 
-export const sdk = new AckLabSdk({
+export const sdk = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+  agentId: process.env.ACK_LAB_AGENT_ID!,
+  baseUrl: process.env.ACK_LAB_BASE_URL!
 })
 
 export async function processMessage({ receipt }: Input): Promise<Output> {

--- a/examples/paywall/app/api/chat/fixed-price/agent.ts
+++ b/examples/paywall/app/api/chat/fixed-price/agent.ts
@@ -37,8 +37,7 @@ type Output = v.InferOutput<typeof _outputSchema>
 export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
-  agentId: process.env.ACK_LAB_AGENT_ID!,
-  baseUrl: process.env.ACK_LAB_BASE_URL!
+  agentId: process.env.ACK_LAB_AGENT_ID!
 })
 
 export async function processMessage({ receipt }: Input): Promise<Output> {

--- a/examples/paywall/app/api/chat/fixed-price/agent.ts
+++ b/examples/paywall/app/api/chat/fixed-price/agent.ts
@@ -34,7 +34,7 @@ const _outputSchema = v.object({
 
 type Output = v.InferOutput<typeof _outputSchema>
 
-export const sdk = new AckLabAgent({
+export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
   agentId: process.env.ACK_LAB_AGENT_ID!,
@@ -47,7 +47,7 @@ export async function processMessage({ receipt }: Input): Promise<Output> {
     console.log(receipt)
 
     //verify the receipt is valid
-    const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+    const { paymentRequestId } = await agent.verifyPaymentReceipt(receipt)
 
     //check to see if we ever made a PRT for this receipt
     const prt = await getDbPaymentRequest(paymentRequestId)
@@ -77,7 +77,7 @@ export async function processMessage({ receipt }: Input): Promise<Output> {
       .returning()
 
     //now create the payment request itself using the ACK Lab SDK
-    const { paymentRequestToken } = await sdk.createPaymentRequest({
+    const { paymentRequestToken } = await agent.createPaymentRequest({
       description: `Purchase ${product.title}`,
       amount: product.price,
       currencyCode: "USD",
@@ -93,4 +93,4 @@ export async function processMessage({ receipt }: Input): Promise<Output> {
 
 // Create an agent handler that will process incoming messages
 // This uses the ACK Lab SDK to provide a secure communication channel between the buyer and the seller
-export const handler = sdk.createRequestHandler(inputSchema, processMessage)
+export const handler = agent.createRequestHandler(inputSchema, processMessage)

--- a/examples/paywall/app/api/chat/negotiate/README.md
+++ b/examples/paywall/app/api/chat/negotiate/README.md
@@ -72,7 +72,7 @@ createPaymentRequest: tool({
       .returning()
 
     // Create ACK Lab payment request
-    const { paymentRequestToken } = await sdk.createPaymentRequest({
+    const { paymentRequestToken } = await agent.createPaymentRequest({
       description: description,
       amount: product.price * 100, // Convert to cents
       currencyCode: "USD",
@@ -93,7 +93,7 @@ When buyers submit receipts, the system validates and delivers content:
 ```typescript
 if (receipt) {
   // Verify receipt cryptographically
-  const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+  const { paymentRequestId } = await agent.verifyPaymentReceipt(receipt)
 
   // Verify we created this payment request
   const prt = await getDbPaymentRequest(paymentRequestId)

--- a/examples/paywall/app/api/chat/negotiate/agent.ts
+++ b/examples/paywall/app/api/chat/negotiate/agent.ts
@@ -83,7 +83,7 @@ const _outputSchema = v.object({
 type Output = v.InferOutput<typeof _outputSchema>
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const sdk = new AckLabAgent({
+export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
   agentId: process.env.ACK_LAB_AGENT_ID!,
@@ -133,7 +133,7 @@ export async function processMessage({
     console.log("Receipt received:", receipt)
 
     //verify the receipt is valid
-    const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+    const { paymentRequestId } = await agent.verifyPaymentReceipt(receipt)
 
     //check to see if we ever made a PRT for this receipt
     const prt = await getDbPaymentRequest(paymentRequestId)
@@ -195,7 +195,7 @@ export async function processMessage({
             .returning()
 
           //now create the payment request itself using the ACK Lab SDK
-          const paymentRequest = await sdk.createPaymentRequest({
+          const paymentRequest = await agent.createPaymentRequest({
             description: description,
             amount: amount * 100,
             currencyCode: "USD",
@@ -221,4 +221,4 @@ export async function processMessage({
 
 // Create an agent handler that will process incoming messages
 // This uses the ACK Lab SDK to provide a secure communication channel between the buyer and the seller
-export const handler = sdk.createRequestHandler(inputSchema, processMessage)
+export const handler = agent.createRequestHandler(inputSchema, processMessage)

--- a/examples/paywall/app/api/chat/negotiate/agent.ts
+++ b/examples/paywall/app/api/chat/negotiate/agent.ts
@@ -4,7 +4,7 @@
  */
 import { generateText, stepCountIs, tool } from "ai"
 import { openai } from "@ai-sdk/openai"
-import { AckLabAgent } from "@ack-lab/sdk"
+import { AckLabSdk } from "@ack-lab/sdk"
 import { z } from "zod"
 import * as v from "valibot"
 import { getDbPaymentRequest } from "@/db/queries/payment-requests"
@@ -83,11 +83,12 @@ const _outputSchema = v.object({
 type Output = v.InferOutput<typeof _outputSchema>
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const agent = new AckLabAgent({
+const sdk = new AckLabSdk({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
-  agentId: process.env.ACK_LAB_AGENT_ID!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
 })
+
+const agent = sdk.agent(process.env.ACK_LAB_AGENT_ID!)
 
 // As this is an agent that performs a negotiation, we need to persist the conversation
 // somewhere. In this very basic example we use an in-memory store, but in a production

--- a/examples/paywall/app/api/chat/negotiate/agent.ts
+++ b/examples/paywall/app/api/chat/negotiate/agent.ts
@@ -4,7 +4,7 @@
  */
 import { generateText, stepCountIs, tool } from "ai"
 import { openai } from "@ai-sdk/openai"
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import { z } from "zod"
 import * as v from "valibot"
 import { getDbPaymentRequest } from "@/db/queries/payment-requests"
@@ -83,9 +83,11 @@ const _outputSchema = v.object({
 type Output = v.InferOutput<typeof _outputSchema>
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const sdk = new AckLabSdk({
+export const sdk = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+  agentId: process.env.ACK_LAB_AGENT_ID!,
+  baseUrl: process.env.ACK_LAB_BASE_URL!
 })
 
 // As this is an agent that performs a negotiation, we need to persist the conversation

--- a/examples/paywall/app/api/chat/negotiate/agent.ts
+++ b/examples/paywall/app/api/chat/negotiate/agent.ts
@@ -86,8 +86,7 @@ type Output = v.InferOutput<typeof _outputSchema>
 export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
-  agentId: process.env.ACK_LAB_AGENT_ID!,
-  baseUrl: process.env.ACK_LAB_BASE_URL!
+  agentId: process.env.ACK_LAB_AGENT_ID!
 })
 
 // As this is an agent that performs a negotiation, we need to persist the conversation

--- a/examples/paywall/app/api/fixed-price/README.md
+++ b/examples/paywall/app/api/fixed-price/README.md
@@ -41,7 +41,7 @@ When a receipt is provided, the system validates and delivers the product:
 ```typescript
 if (receipt) {
   //verify the receipt is valid
-  const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+  const { paymentRequestId } = await agent.verifyPaymentReceipt(receipt)
 
   //check to see if we ever made a PRT for this receipt
   const prt = await getDbPaymentRequest(paymentRequestId)
@@ -77,7 +77,7 @@ const prt = await db
   .returning()
 
 //now create the payment request itself using the ACK Lab SDK
-const { paymentRequestToken } = await sdk.createPaymentRequest({
+const { paymentRequestToken } = await agent.createPaymentRequest({
   amount: productPrice,
   currencyCode: "USD",
   description: "Test payment request",
@@ -124,7 +124,7 @@ The buyer script (`buyer/scripts/buy-fixed-price.ts`) implements:
 1. Makes POST request to `/api/fixed-price` without receipt
 2. Receives 402 status with Payment Request Token
 3. Validates the PRT amount matches expected price ($10)
-4. Executes payment using `sdk.executePayment()`
+4. Executes payment using `agent.executePayment()`
 5. Makes second POST request with receipt to receive digital product
 
 ## Environment Variables

--- a/examples/paywall/app/api/fixed-price/route.ts
+++ b/examples/paywall/app/api/fixed-price/route.ts
@@ -6,16 +6,18 @@
  * If the buyer sends a receipt, it will validate it and return the digital product.
  * If not, it will send a payment request token.
  */
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import * as v from "valibot"
 import { getDbPaymentRequest } from "@/db/queries/payment-requests"
 import { db } from "@/db"
 import { paymentRequestsTable } from "@/db/schema"
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const sdk = new AckLabSdk({
+export const sdk = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+  agentId: process.env.ACK_LAB_AGENT_ID!,
+  baseUrl: process.env.ACK_LAB_BASE_URL!
 })
 
 const requestSchema = v.object({ receipt: v.optional(v.string()) })

--- a/examples/paywall/app/api/fixed-price/route.ts
+++ b/examples/paywall/app/api/fixed-price/route.ts
@@ -13,7 +13,7 @@ import { db } from "@/db"
 import { paymentRequestsTable } from "@/db/schema"
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const sdk = new AckLabAgent({
+export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
   agentId: process.env.ACK_LAB_AGENT_ID!,
@@ -34,7 +34,7 @@ export async function POST(req: Request) {
     console.log("Received a receipt from the buyer")
 
     // verify the receipt is valid
-    const { paymentRequestId } = await sdk.verifyPaymentReceipt(receipt)
+    const { paymentRequestId } = await agent.verifyPaymentReceipt(receipt)
 
     // check to see if we ever made a PRT for this receipt
     const prt = await getDbPaymentRequest(paymentRequestId)
@@ -62,7 +62,7 @@ export async function POST(req: Request) {
       .returning()
 
     // Now create the payment request itself using the ACK Lab SDK
-    const { paymentRequestToken } = await sdk.createPaymentRequest({
+    const { paymentRequestToken } = await agent.createPaymentRequest({
       amount: productPrice,
       currencyCode: "USD",
       description: "Test payment request",

--- a/examples/paywall/app/api/fixed-price/route.ts
+++ b/examples/paywall/app/api/fixed-price/route.ts
@@ -16,8 +16,7 @@ import { paymentRequestsTable } from "@/db/schema"
 export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
-  agentId: process.env.ACK_LAB_AGENT_ID!,
-  baseUrl: process.env.ACK_LAB_BASE_URL!
+  agentId: process.env.ACK_LAB_AGENT_ID!
 })
 
 const requestSchema = v.object({ receipt: v.optional(v.string()) })

--- a/examples/paywall/app/api/images/buy/README.md
+++ b/examples/paywall/app/api/images/buy/README.md
@@ -46,7 +46,7 @@ After storing our record, we create the actual payment request with ACK Lab:
 
 ```typescript
 //now create the payment request itself using the ACK Lab SDK
-const { paymentRequestToken } = await sdk.createPaymentRequest({
+const { paymentRequestToken } = await agent.createPaymentRequest({
   amount: price,
   currencyCode: "USD",
   description: `Purchase of ${count} image generation credits`,
@@ -106,7 +106,7 @@ The buyer script (`buyer/scripts/images.ts`) demonstrates the full workflow:
 1. Makes POST request to `/api/images/buy` requesting 3 credits
 2. Receives 402 status with Payment Request Token for $3
 3. Validates the PRT amount matches expected price ($1 per credit)
-4. Executes payment using `sdk.executePayment()`
+4. Executes payment using `agent.executePayment()`
 5. Uses the receipt to generate 2 random president images at `/api/images/generate`
 6. Saves images locally, leaving 1 credit remaining on the receipt
 

--- a/examples/paywall/app/api/images/buy/route.ts
+++ b/examples/paywall/app/api/images/buy/route.ts
@@ -5,7 +5,7 @@
  * This endpoint allows a buyer to purchase the right to generate a number of images.
  */
 import * as v from "valibot"
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import { db } from "@/db"
 import { paymentRequestsTable } from "@/db/schema"
 
@@ -14,9 +14,11 @@ const requestSchema = v.object({
 })
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const sdk = new AckLabSdk({
+export const sdk = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+  agentId: process.env.ACK_LAB_AGENT_ID!,
+  baseUrl: process.env.ACK_LAB_BASE_URL!
 })
 
 const pricePerImage = 1 * 100 // 1 USD in cents

--- a/examples/paywall/app/api/images/buy/route.ts
+++ b/examples/paywall/app/api/images/buy/route.ts
@@ -14,7 +14,7 @@ const requestSchema = v.object({
 })
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const sdk = new AckLabAgent({
+export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
   agentId: process.env.ACK_LAB_AGENT_ID!,
@@ -35,7 +35,7 @@ export async function POST(req: Request) {
     .returning()
 
   // Now create the payment request itself using the ACK Lab SDK
-  const { paymentRequestToken } = await sdk.createPaymentRequest({
+  const { paymentRequestToken } = await agent.createPaymentRequest({
     amount: price,
     currencyCode: "USD",
     description: `Purchase of ${count} image generation credits`,

--- a/examples/paywall/app/api/images/buy/route.ts
+++ b/examples/paywall/app/api/images/buy/route.ts
@@ -17,8 +17,7 @@ const requestSchema = v.object({
 export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
-  agentId: process.env.ACK_LAB_AGENT_ID!,
-  baseUrl: process.env.ACK_LAB_BASE_URL!
+  agentId: process.env.ACK_LAB_AGENT_ID!
 })
 
 const pricePerImage = 1 * 100 // 1 USD in cents

--- a/examples/paywall/app/api/images/generate/README.md
+++ b/examples/paywall/app/api/images/generate/README.md
@@ -46,7 +46,7 @@ The receipt undergoes cryptographic verification to ensure authenticity:
 
 ```typescript
 //check the Receipt JWT is valid
-const { paymentRequestId } = await sdk.verifyPaymentReceipt(receiptJwt)
+const { paymentRequestId } = await agent.verifyPaymentReceipt(receiptJwt)
 
 if (!paymentRequestId) {
   return new Response("Invalid receipt", { status: 400 })
@@ -55,7 +55,7 @@ if (!paymentRequestId) {
 
 **Why we do this:**
 
-- `sdk.verifyPaymentReceipt()` cryptographically validates the receipt hasn't been tampered with
+- `agent.verifyPaymentReceipt()` cryptographically validates the receipt hasn't been tampered with
 - It extracts the `paymentRequestId` that links back to the original purchase
 - Invalid receipts are rejected immediately, preventing unauthorized access
 

--- a/examples/paywall/app/api/images/generate/route.ts
+++ b/examples/paywall/app/api/images/generate/route.ts
@@ -19,8 +19,7 @@ const requestSchema = v.object({ receipt: v.string(), name: v.string() })
 export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
-  agentId: process.env.ACK_LAB_AGENT_ID!,
-  baseUrl: process.env.ACK_LAB_BASE_URL!
+  agentId: process.env.ACK_LAB_AGENT_ID!
 })
 
 export async function POST(req: Request) {

--- a/examples/paywall/app/api/images/generate/route.ts
+++ b/examples/paywall/app/api/images/generate/route.ts
@@ -10,15 +10,17 @@ import { consumeReceiptCredit, getOrCreateCredits } from "@/db/queries/credits"
 import * as v from "valibot"
 import { experimental_generateImage as generateImage } from "ai"
 import { openai } from "@ai-sdk/openai"
-import { AckLabSdk } from "@ack-lab/sdk"
+import { AckLabAgent } from "@ack-lab/sdk"
 import { presidents } from "@/data/presidents"
 
 const requestSchema = v.object({ receipt: v.string(), name: v.string() })
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const sdk = new AckLabSdk({
+export const sdk = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
-  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!
+  clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
+  agentId: process.env.ACK_LAB_AGENT_ID!,
+  baseUrl: process.env.ACK_LAB_BASE_URL!
 })
 
 export async function POST(req: Request) {

--- a/examples/paywall/app/api/images/generate/route.ts
+++ b/examples/paywall/app/api/images/generate/route.ts
@@ -16,7 +16,7 @@ import { presidents } from "@/data/presidents"
 const requestSchema = v.object({ receipt: v.string(), name: v.string() })
 
 // Create an ACK Lab SDK instance with the client ID and client secret for the Seller Agent in ACK Lab
-export const sdk = new AckLabAgent({
+export const agent = new AckLabAgent({
   clientId: process.env.ACK_LAB_CLIENT_ID!,
   clientSecret: process.env.ACK_LAB_CLIENT_SECRET!,
   agentId: process.env.ACK_LAB_AGENT_ID!,
@@ -32,7 +32,7 @@ export async function POST(req: Request) {
   }
 
   // check the Receipt JWT is valid
-  const { paymentRequestId } = await sdk.verifyPaymentReceipt(receiptJwt)
+  const { paymentRequestId } = await agent.verifyPaymentReceipt(receiptJwt)
 
   if (!paymentRequestId) {
     return new Response("Invalid receipt", { status: 400 })

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -198,7 +198,7 @@ export class AckLabAgent {
   }
 
   /**
-   * Create a request handler for processing incoming agent messages.
+   * Create a request handler for processing incoming messages from other agents.
    *
    * This method returns a function that can be integrated with any HTTP server
    * framework to handle incoming JWT messages from other agents. It automatically
@@ -299,7 +299,8 @@ export class AckLabAgent {
   }
 
   /**
-   * Create a payment request for the agent.
+   * Create a payment request for the agent. This will generate a payment request token
+   * that another agent can use to pay this one.
    *
    * @param params - The parameters for the payment request
    * @param params.id - The ID of the payment request
@@ -318,7 +319,8 @@ export class AckLabAgent {
   }
 
   /**
-   * Execute a payment request for the agent.
+   * Execute a payment request for the agent. Use this to have this agent pay another agent
+   * via a payment request token.
    *
    * @param paymentRequestToken - The signed payment request token to pay
    * @returns Promise resolving to the payment result

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -45,9 +45,7 @@ async function jwtFetch(url: string, jwt: JwtString) {
 }
 
 /**
- * AckLabSdk - The main SDK for building authenticated agent-to-agent communication.
- *
- * This SDK provides high-level utilities for agent developers to easily implement
+ * This class provides high-level utilities for agent developers to easily implement
  * secure handshake protocols and authenticated messaging between agents. It handles
  * the complex cryptographic handshake flow and provides simple factory methods
  * for creating agent callers and request handlers.
@@ -56,12 +54,13 @@ async function jwtFetch(url: string, jwt: JwtString) {
  * ```ts
  * import * as v from "valibot"
  *
- * const sdk = new AckLabSdk({
+ * const agent = new AckLabAgent({
  *   clientId: "your-client-id",
- *   clientSecret: "your-client-secret"
+ *   clientSecret: "your-client-secret",
+ *   agentId: "your-agent-id"
  * })
  *
- * const callAgent = sdk.createAgentCaller(
+ * const callAgent = agent.createAgentCaller(
  *   "http://localhost:3000/chat",
  *   v.object({ message: v.string() }),
  *   v.string()
@@ -74,8 +73,8 @@ async function jwtFetch(url: string, jwt: JwtString) {
  * ```ts
  * import * as v from "valibot"
  *
- * const sdk = new AckLabSdk(config)
- * const handler = sdk.createRequestHandler(
+ * const agent = new AckLabAgent(config)
+ * const handler = agent.createRequestHandler(
  *   v.object({ message: v.string() }),
  *   async (input) => {
  *     return `You said: ${input.message}`
@@ -90,25 +89,27 @@ async function jwtFetch(url: string, jwt: JwtString) {
  * })
  * ```
  */
-export class AckLabSdk {
+export class AckLabAgent {
   private readonly apiClient: ApiClient
   private readonly handshakeClient: HandshakeClient
   private readonly resolver: Resolvable
 
   /**
-   * Create a new AckLabSdk instance.
+   * Create a new AckLabAgent instance.
    *
    * @param config - API client configuration containing credentials
    * @param config.clientId - Your agent's client ID from the AckLab platform
    * @param config.clientSecret - Your agent's client secret from the AckLab platform
+   * @param config.agentId - Your agent's ID from the AckLab platform
    * @param opts - Optional configuration
    * @param opts.resolver - Custom DID resolver (defaults to standard resolver)
    *
    * @example
    * ```ts
-   * const sdk = new AckLabSdk({
+   * const agent = new AckLabAgent({
    *   clientId: "jkbouswwx3jz1zvz7hxgs3ff",
-   *   clientSecret: "5a2b23d8408a1f7ea407eea43166553c2f50c8dbbee00b6f9ef159e1266601e8"
+   *   clientSecret: "5a2b23d8408a1f7ea407eea43166553c2f50c8dbbee00b6f9ef159e1266601e8",
+   *   agentId: "my-agent-id"
    * })
    * ```
    */
@@ -138,7 +139,7 @@ export class AckLabSdk {
    * ```ts
    * import * as v from "valibot"
    *
-   * const callMathAgent = sdk.createAgentCaller(
+   * const callMathAgent = agent.createAgentCaller(
    *   "http://localhost:3001/chat",
    *   v.object({ message: v.string() }),
    *   v.string()
@@ -154,7 +155,7 @@ export class AckLabSdk {
    * ```ts
    * import * as v from "valibot"
    *
-   * const callAgent = sdk.createAgentCaller(
+   * const callAgent = agent.createAgentCaller(
    *   "http://localhost:3001/chat",
    *   v.object({ message: v.string() }),
    *   v.string()
@@ -212,7 +213,7 @@ export class AckLabSdk {
    * ```ts
    * import * as v from "valibot"
    *
-   * const handler = sdk.createRequestHandler(
+   * const handler = agent.createRequestHandler(
    *   v.object({ message: v.string() }),
    *   async (input) => {
    *     return `Echo: ${input.message}`
@@ -234,7 +235,7 @@ export class AckLabSdk {
    * ```ts
    * import * as v from "valibot"
    *
-   * const handler = sdk.createRequestHandler(
+   * const handler = agent.createRequestHandler(
    *   v.object({ message: v.string() }),
    *   async ({ message }) => {
    *     // Use AI to generate response

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,7 +10,7 @@ import {
 import { jwtStringSchema } from "agentcommercekit/schemas/valibot"
 import * as s from "standard-parse"
 import * as v from "valibot"
-import { ApiClient, HandshakeClient, type ApiClientConfig } from "./core"
+import { ApiClient, HandshakeClient, type AckLabAgentConfig } from "./core"
 
 type MessageHandler<TInput> = (input: TInput) => Promise<unknown>
 type RequestHandler = (jwt: JwtString) => Promise<{ jwt: JwtString }>
@@ -113,7 +113,7 @@ export class AckLabAgent {
    * })
    * ```
    */
-  constructor(config: ApiClientConfig, opts?: { resolver?: Resolvable }) {
+  constructor(config: AckLabAgentConfig, opts?: { resolver?: Resolvable }) {
     this.resolver = opts?.resolver ?? getDidResolver()
 
     this.apiClient = new ApiClient(config)

--- a/src/core/api-client.ts
+++ b/src/core/api-client.ts
@@ -43,13 +43,15 @@ export class ApiClient {
   private readonly baseUrl: string
   private readonly clientId: string
   private readonly clientSecret: string
+  private readonly agentId: string
 
   private _metadata: AgentMetadata | undefined = undefined
 
-  constructor({ baseUrl, clientId, clientSecret }: ApiClientConfig) {
+  constructor({ baseUrl, clientId, clientSecret, agentId }: ApiClientConfig) {
     this.baseUrl = baseUrl ?? "https://api.ack-lab.com"
     this.clientId = clientId
     this.clientSecret = clientSecret
+    this.agentId = agentId
   }
 
   async getMetadata(): Promise<AgentMetadata> {
@@ -68,9 +70,13 @@ export class ApiClient {
     return metadata
   }
 
+  agentPath(subPath: string): string {
+    return `/v1/agents/${this.agentId}/${subPath}`
+  }
+
   async getBalance(): Promise<Record<string, string>> {
     return this.request(
-      { method: "GET", path: "/v1/balance" },
+      { method: "GET", path: this.agentPath("balance") },
       v.record(v.string(), v.string())
     )
   }
@@ -89,7 +95,7 @@ export class ApiClient {
     return this.request(
       {
         method: "POST",
-        path: "/v1/payment-requests",
+        path: this.agentPath("payment-requests"),
         body: { id, amount, currencyCode, description }
       },
       v.object({ paymentRequestToken: v.string(), url: v.optional(v.string()) })
@@ -102,7 +108,7 @@ export class ApiClient {
     return this.request(
       {
         method: "POST",
-        path: "/v1/payments",
+        path: this.agentPath("payments"),
         body: { paymentRequestToken }
       },
       v.object({ receipt: jwtStringSchema, url: v.optional(v.string()) })
@@ -117,7 +123,7 @@ export class ApiClient {
    */
   async sign(payload: unknown): Promise<{ jwt: JwtString }> {
     return this.request(
-      { method: "POST", path: "/v1/sign", body: payload },
+      { method: "POST", path: this.agentPath("sign"), body: payload },
       v.object({ jwt: jwtStringSchema })
     )
   }
@@ -140,7 +146,7 @@ export class ApiClient {
     return this.request(
       {
         method: "POST",
-        path: "/v1/verifiable-presentations",
+        path: this.agentPath("verifiable-presentations"),
         body: { aud, challenge, nonce }
       },
       v.object({ presentation: jwtStringSchema })

--- a/src/core/api-client.ts
+++ b/src/core/api-client.ts
@@ -12,7 +12,7 @@ import { stringify } from "safe-stable-stringify"
 import * as v from "valibot"
 import { sha256 } from "../utils/sha-256"
 import { ApiError, apiErrorIssuesSchema } from "./errors/api-error"
-import type { ApiClientConfig } from "./types"
+import type { AckLabAgentConfig } from "./types"
 
 export interface RequestOptions {
   method: string
@@ -47,7 +47,7 @@ export class ApiClient {
 
   private _metadata: AgentMetadata | undefined = undefined
 
-  constructor({ baseUrl, clientId, clientSecret, agentId }: ApiClientConfig) {
+  constructor({ baseUrl, clientId, clientSecret, agentId }: AckLabAgentConfig) {
     this.baseUrl = baseUrl ?? "https://api.ack-lab.com"
     this.clientId = clientId
     this.clientSecret = clientSecret

--- a/src/core/handshake.ts
+++ b/src/core/handshake.ts
@@ -53,7 +53,7 @@ export class HandshakeClient {
    * @returns Object containing the response JWT to send back
    * @example
    * ```ts
-   * const response = await sdk.handleHandshakeInit(initJwt)
+   * const response = await client.handleHandshakeInit(initJwt)
    * // => { jwt: JwtString<VerifiablePresentation> }
    * ```
    */
@@ -80,7 +80,7 @@ export class HandshakeClient {
    * @returns Object containing the continuation JWT and counterparty DID
    * @example
    * ```ts
-   * const continuation = await sdk.handleHandshakeResponse(responseJwt)
+   * const continuation = await client.handleHandshakeResponse(responseJwt)
    * // => { jwt: JwtString<VerifiablePresentation>, counterpartyDid: "did:web:agentB" }
    * ```
    */
@@ -116,7 +116,7 @@ export class HandshakeClient {
    * @returns Object containing the completion JWT and counterparty DID
    * @example
    * ```ts
-   * const completion = await sdk.finalizeHandshake(continuationJwt)
+   * const completion = await client.finalizeHandshake(continuationJwt)
    * // => { counterpartyDid: "did:web:agentA", jwt: JwtString<{type: "handshake-complete"}> }
    * ```
    */
@@ -146,7 +146,7 @@ export class HandshakeClient {
    * @returns Object containing the verified payload and counterparty DID
    * @example
    * ```ts
-   * const result = await sdk.verifyHandshakeComplete(completionJwt)
+   * const result = await client.verifyHandshakeComplete(completionJwt)
    * // => { payload: JwtPayload, counterpartyDid: "did:web:agentB" }
    * ```
    */
@@ -188,9 +188,9 @@ export class HandshakeClient {
    * @returns The classified request type
    * @example
    * ```ts
-   * const type = sdk.getRequestType(incomingJwt)
+   * const type = client.getRequestType(incomingJwt)
    * if (type === "handshake-init") {
-   *   await sdk.handleHandshakeInit(incomingJwt)
+   *   await client.handleHandshakeInit(incomingJwt)
    * }
    * ```
    */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,6 +2,7 @@ export interface ApiClientConfig {
   baseUrl?: string
   clientId: string
   clientSecret: string
+  agentId: string
 }
 
 export interface AckHubSdkConfig extends ApiClientConfig {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,10 +2,13 @@ export interface ApiClientConfig {
   baseUrl?: string
   clientId: string
   clientSecret: string
-  agentId: string
 }
 
 export interface AckHubSdkConfig extends ApiClientConfig {
   trustedIssuers?: string[]
   trustedAgentControllers?: string[]
+}
+
+export interface AckLabAgentConfig extends ApiClientConfig {
+  agentId: string
 }

--- a/src/demo/addition-demo.ts
+++ b/src/demo/addition-demo.ts
@@ -3,7 +3,7 @@ import { input } from "@inquirer/prompts"
 import { generateText, stepCountIs, tool } from "ai"
 import colors from "yoctocolors"
 import { z } from "zod"
-import { AckLabSdk } from "../sdk"
+import { AckLabAgent } from "../agent"
 import { serveAgent, serveAuthedAgent } from "./serve-agent"
 
 async function runAgentB(message: string) {
@@ -28,7 +28,7 @@ async function runAgentB(message: string) {
   return result.text
 }
 
-const ackLabSdk = new AckLabSdk({
+const ackLabSdk = new AckLabAgent({
   clientId: "<client-id>",
   clientSecret: "<client-secret>"
 })
@@ -84,7 +84,7 @@ async function main() {
   serveAuthedAgent({
     port: 7577,
     runAgent: runAgentB,
-    sdk: new AckLabSdk({
+    sdk: new AckLabAgent({
       clientId: "<client-id>",
       clientSecret: "<client-secret>"
     })

--- a/src/demo/addition-demo.ts
+++ b/src/demo/addition-demo.ts
@@ -28,12 +28,13 @@ async function runAgentB(message: string) {
   return result.text
 }
 
-const ackLabSdk = new AckLabAgent({
+const ackLabAgent = new AckLabAgent({
   clientId: "<client-id>",
-  clientSecret: "<client-secret>"
+  clientSecret: "<client-secret>",
+  agentId: "<agent-id>"
 })
 
-const callAgent = ackLabSdk.createAgentCaller(
+const callAgent = ackLabAgent.createAgentCaller(
   "http://localhost:7577/chat",
   z.string(),
   z.string()
@@ -84,9 +85,10 @@ async function main() {
   serveAuthedAgent({
     port: 7577,
     runAgent: runAgentB,
-    sdk: new AckLabAgent({
+    agent: new AckLabAgent({
       clientId: "<client-id>",
-      clientSecret: "<client-secret>"
+      clientSecret: "<client-secret>",
+      agentId: "<agent-id>"
     })
   })
 

--- a/src/demo/payment-flow.ts
+++ b/src/demo/payment-flow.ts
@@ -1,15 +1,17 @@
 import colors from "yoctocolors"
-import { AckLabSdk } from "../sdk"
+import { AckLabAgent } from "../agent"
 
 async function main() {
-  const sellerClient = new AckLabSdk({
+  const sellerClient = new AckLabAgent({
     clientId: "<client-id>",
-    clientSecret: "<client-secret>"
+    clientSecret: "<client-secret>",
+    agentId: "<seller-agent-id>"
   })
 
-  const buyerClient = new AckLabSdk({
+  const buyerClient = new AckLabAgent({
     clientId: "<client-id>",
-    clientSecret: "<client-secret>"
+    clientSecret: "<client-secret>",
+    agentId: "<buyer-agent-id>"
   })
 
   const { paymentRequestToken } = await sellerClient.createPaymentRequest({

--- a/src/demo/serve-agent.ts
+++ b/src/demo/serve-agent.ts
@@ -15,17 +15,17 @@ interface ServeAgentConfig {
 }
 
 interface ServeAuthedAgentConfig extends ServeAgentConfig {
-  sdk: AckLabAgent
+  agent: AckLabAgent
 }
 
 export function serveAuthedAgent({
   port,
   runAgent,
-  sdk
+  agent
 }: ServeAuthedAgentConfig) {
   console.log(`> Starting local server...`)
 
-  const agentHandler = sdk.createRequestHandler(v.string(), runAgent)
+  const agentHandler = agent.createRequestHandler(v.string(), runAgent)
 
   const app = new Hono()
 

--- a/src/demo/serve-agent.ts
+++ b/src/demo/serve-agent.ts
@@ -5,7 +5,7 @@ import { jwtStringSchema } from "agentcommercekit/schemas/valibot"
 import { Hono, type TypedResponse } from "hono"
 import { logger } from "hono/logger"
 import * as v from "valibot"
-import type { AckLabSdk } from "../sdk"
+import type { AckLabAgent } from "../agent"
 
 type AgentFn = (prompt: string) => Promise<string>
 
@@ -15,7 +15,7 @@ interface ServeAgentConfig {
 }
 
 interface ServeAuthedAgentConfig extends ServeAgentConfig {
-  sdk: AckLabSdk
+  sdk: AckLabAgent
 }
 
 export function serveAuthedAgent({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./sdk"
+export * from "./agent"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./agent"
+export * from "./sdk"

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,0 +1,61 @@
+import type { ApiClientConfig } from "./core/types"
+import { AckLabAgent } from "./agent"
+
+/**
+ * Top-level SDK class for interacting with the ACK Lab platform.
+ *
+ * @example
+ * ```ts
+ * // the client ID and secret can be used across multiple agents
+ * // Generate a client ID and secret at https://ack-lab.catenalabs.com
+ * const sdk = new AckLabSdk({
+ *   clientId: "your-client-id",
+ *   clientSecret: "your-client-secret",
+ * })
+ *
+ * const agent = sdk.agent({ agentId: "your-agent-id" })
+ *
+ * agent.createPaymentRequest({
+ *   id: "your-payment-request-id",
+ *   amount: 100,
+ *   currencyCode: "USD",
+ *   description: "Service fee"
+ * })
+ *
+ * // the same SDK instance can be used to control multiple agents in the same organization
+ * const payerAgent = sdk.agent({ agentId: "payer-agent-id" })
+ * const receipt = await payerAgent.executePayment(paymentRequestToken)
+ *
+ * // cryptographically verify the receipt
+ * const { paymentRequestId, receipt } = await payerAgent.verifyPaymentReceipt(receipt)
+ *
+ * ```
+ */
+export class AckLabSdk {
+  private readonly agents: Map<string, AckLabAgent>
+  private readonly config: ApiClientConfig
+
+  constructor(config: ApiClientConfig) {
+    this.agents = new Map()
+    this.config = config
+  }
+
+  /**
+   * Get an agent instance by ID.
+   *
+   * @param agentId - The ID of the agent
+   * @returns The agent instance
+   */
+  agent(agentId: string): AckLabAgent {
+    if (this.agents.has(agentId)) {
+      const agent = this.agents.get(agentId)
+
+      if (agent) {
+        return agent
+      }
+    }
+    const agent = new AckLabAgent({ ...this.config, agentId })
+    this.agents.set(agentId, agent)
+    return agent
+  }
+}


### PR DESCRIPTION
Renames `AckLabSdk` to `AckLabAgent`, introduces `agentId` as a required parameter. Allows use of organization-level API keys. Uses the new /v1/agents/:agent_id/* ACK Lab endpoints.

This is a breaking change. The upgrade path is to simply replace all instances of `AckLabSdk` with `AckLabAgent` and provide the agentId in the constructor.

All of the examples have been updated to use `AckLabAgent`, and READMEs have been updated and expanded with additional context for onboarding devs.