### PR TITLE
Prepend /agents/:id to agent metadata fetch

### DIFF
--- a/src/core/api-client.ts
+++ b/src/core/api-client.ts
@@ -61,7 +61,7 @@ export class ApiClient {
     }
 
     const metadata = await this.request(
-      { method: "GET", path: "/v1/metadata" },
+      { method: "GET", path: this.agentPath("metadata") },
       agentMetadataSchema
     )
 


### PR DESCRIPTION
This should have been in 0.1.0, so I will cut a 0.1.1 to address it.