### PR TITLE
update docs to clarify jwt url expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const agent = new AckLabAgent({
 })
 
 // Generate a request for our agent to get paid
-const paymentRequest = await agent.createPaymentRequest({
+const { paymentRequestToken, url } = await agent.createPaymentRequest({
   id: crypto.randomUUID(),
   amount: 100,
   currencyCode: "USD",
@@ -89,7 +89,7 @@ The ACK Lab SDK offers a collection of agent-centric actions that can be perform
 An Agent can generate a payment request token that can be sent to another agent:
 
 ```ts
-const paymentRequest = await agent.createPaymentRequest({
+const { paymentRequestToken, url } = await agent.createPaymentRequest({
   id: crypto.randomUUID(),
   amount: 100,
   currencyCode: "USD",
@@ -217,7 +217,7 @@ The schema parameter accepts any [Standard Schema](https://standardschema.dev/) 
 ### createPaymentRequest(params: { id?: string, amount: number, currencyCode?: string, description?: string })
 
 ```ts
-const paymentRequest = await agent.createPaymentRequest({
+const { paymentRequestToken, url } = await agent.createPaymentRequest({
   id: crypto.randomUUID(),
   amount: 100,
   currencyCode: "USD",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -307,7 +307,8 @@ export class AckLabAgent {
    * @param params.amount - The amount to request in minor units (e.g. 1000 for $10 in USD)
    * @param params.currencyCode - The currency code to request (e.g. "USD")
    * @param params.description - Optional description of the payment request
-   * @returns Promise resolving to the payment request token
+   * @returns Promise resolving to an object with paymentRequestToken (string) and
+   * optional url (string, expires after 1 day) that resolves to the JWT token.
    */
   async createPaymentRequest(params: {
     id?: string
@@ -323,7 +324,8 @@ export class AckLabAgent {
    * via a payment request token.
    *
    * @param paymentRequestToken - The signed payment request token to pay
-   * @returns Promise resolving to the payment result
+   * @returns Promise resolving to an object with receipt (JwtString) and optional
+   * url (string, expires after 1 day) that resolves to the JWT receipt.
    */
   async executePayment(paymentRequestToken: string) {
     return this.apiClient.executePayment(paymentRequestToken)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated examples to destructure createPaymentRequest results into paymentRequestToken and url across Quick Start, Payments, and API snippet.
  * Clarified method return descriptions to indicate an object containing the token/receipt plus an optional url.
  * No changes to runtime behavior or public API signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->